### PR TITLE
Fix Command key icon vertical alignment in CommandPalette(Navbar)

### DIFF
--- a/src/components/layout/command-palette.tsx
+++ b/src/components/layout/command-palette.tsx
@@ -95,8 +95,8 @@ export function CommandPalette() {
           <HugeiconsIcon icon={SearchIcon} strokeWidth={2} className="size-4" />
           <span className='hidden md:block'>Search components...</span>
         </div>
-        <kbd className="pointer-events-none flex h-5 select-none items-center gap-0.5 rounded-md border border-input/50 bg-muted/50 px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
-          <span className="text-xs">⌘</span>K
+        <kbd className="pointer-events-none flex h-5 select-none items-center gap-0.5 rounded-md border border-input/50 bg-muted/50 px-1.5 font-mono text-[10px] font-medium text-muted-foreground leading-none">
+          <HugeiconsIcon icon={CommandIcon} size={13} />K
         </kbd>
       </button>
 


### PR DESCRIPTION
## What does this PR do?
Fixes the vertical alignment of the Ctrl/Command key icon in the CommandPalette. 
The icon was appearing slightly higher than center, this PR centers it properly inside the button.

## Changes Made
- Fixed vertical alignment of Command key icon in CommandPalette component

Closes #38 
