### PR TITLE
fix: prevent registry card tooltip from stealing hover

### DIFF
--- a/src/components/animate-ui/primitives/animate/tooltip.tsx
+++ b/src/components/animate-ui/primitives/animate/tooltip.tsx
@@ -286,6 +286,7 @@ function TooltipOverlay() {
       {rendered.data && ready && (
         <TooltipPortal>
           <div
+            className="pointer-events-none"
             ref={refs.setFloating}
             data-slot="tooltip-overlay"
             data-side={resolvedSide}


### PR DESCRIPTION
## Description

Prevent the registry card copy tooltip from intercepting pointer hover and causing the home page card hover state to flicker.
This change makes the tooltip non-interactive so it does not sit between the cursor and the hovered card. That keeps the registry card preview and hover affordances stable when moving across the copy button area.

Fixes #84 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified locally by hovering featured registry cards on the home page and moving across the copy button/tooltip area to confirm the hover state remains stable.

- [x] Tested locally with dev server
- [x] Checked against Lint & TypeScript errors

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Added new component/dashboard to registry and checked indexing numbers