### PR TITLE
fix(ui): prevent header compression in component preview overlay at 1024 - 1120px

### DIFF
--- a/src/components/registry/component-modal.tsx
+++ b/src/components/registry/component-modal.tsx
@@ -526,13 +526,13 @@ useEffect(() => {
         <Tabs defaultValue="preview" className="flex-1 min-w-0 flex flex-col h-full bg-muted/10">
 
           {/* Toolbar with tabs */}
-          <div className="flex items-center justify-between px-4 py-2 border-b bg-muted/30">
-            <TabsList>
-              <TabsTrigger value="preview">
+          <div className="flex items-center justify-between px-2 md:px-4 py-2 border-b bg-muted/30 gap-1 md:gap-2 min-w-0">
+            <TabsList className="shrink-0">
+              <TabsTrigger value="preview" className="text-xs md:text-sm px-2 md:px-3">
                 <HugeiconsIcon icon={ViewIcon} size={14} />
                 Preview
               </TabsTrigger>
-              <TabsTrigger value="code">
+              <TabsTrigger value="code" className="text-xs md:text-sm px-2 md:px-3">
                 <HugeiconsIcon icon={SourceCodeIcon} size={14} />
                 Code
               </TabsTrigger>
@@ -540,10 +540,10 @@ useEffect(() => {
 
             {/* Variant toggle */}
             {item.hasVariants && (
-              <div className="flex items-center rounded-lg border bg-muted p-0.5 gap-0.5 text-xs">
+              <div className="flex items-center rounded-lg border bg-muted p-0.5 gap-0.5 text-xs shrink-0">
                 <button
                   onClick={() => setActiveCodeTab('original')}
-                  className={`px-3 py-1.5 rounded-md font-medium transition-colors ${
+                  className={`px-2 md:px-3 py-1 md:py-1.5 rounded-md font-medium transition-colors ${
                     activeCodeTab === 'original'
                       ? 'bg-background shadow-sm text-foreground'
                       : 'text-muted-foreground hover:text-foreground'
@@ -553,7 +553,7 @@ useEffect(() => {
                 </button>
                 <button
                   onClick={() => setActiveCodeTab('base')}
-                  className={`px-3 py-1.5 rounded-md font-medium transition-colors ${
+                  className={`px-2 md:px-3 py-1 md:py-1.5 rounded-md font-medium transition-colors ${
                     activeCodeTab === 'base'
                       ? 'bg-background shadow-sm text-foreground'
                       : 'text-muted-foreground hover:text-foreground'
@@ -565,18 +565,19 @@ useEffect(() => {
             )}
 
             {/* Actions */}
-            <div className="flex items-center gap-2 mr-8">
+            <div className="flex items-center gap-1 md:gap-2 shrink-0 pr-8">
               <Link
                 to={`/components/${item.slug}`}
                 onClick={onClose}
-                className="flex items-center gap-1.5 px-3 py-2 text-sm tracking-tight text-primary rounded-md group transition-colors"
+                className="flex items-center gap-1 md:gap-1.5 px-2 md:px-3 py-1.5 md:py-2 text-xs md:text-sm tracking-tight text-primary rounded-md group transition-colors whitespace-nowrap"
               >
-                Open Full Page
+                <span className="hidden min-[1120px]:inline">Open Full Page</span>
+                <span className="min-[1120px]:hidden">Open</span>
                 <HugeiconsIcon icon={ArrowUpRight01FreeIcons} size={14} className='group-hover:translate-x-1 transition-transform duration-300' />
               </Link>
               <ThemeToggle />
               <button
-                className="p-2 bg-background/80 backdrop-blur rounded-md border shadow-sm hover:bg-accent transition-colors"
+                className="p-1.5 md:p-2 bg-background/80 backdrop-blur rounded-md border shadow-sm hover:bg-accent transition-colors"
                 onClick={handleReload}
                 aria-label="Reload component preview"
                 title="Reload preview"
@@ -589,23 +590,23 @@ useEffect(() => {
           {/* Content */}
           <div className="flex-1 overflow-y-auto relative">
             {/* Preview Panel */}
-            <TabsContent value="preview"  className="data-[state=inactive]:hidden">
+            <TabsContent value="preview" className="data-[state=inactive]:hidden">
               <div className="h-full flex items-center justify-center p-10 bg-[radial-gradient(circle_at_center,_var(--tw-gradient-stops))] from-muted/50 via-transparent to-transparent">
-              
-                  <Suspense fallback={
-                    <div className="flex items-center gap-2 text-muted-foreground text-sm">
-                      <div className="h-4 w-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
-                      Loading component...
-                    </div>
-                  }>
-                    <ActiveComponent key={`${reloadKey}-${activeCodeTab}`} />
-                  </Suspense>
-               
+
+                <Suspense fallback={
+                  <div className="flex items-center gap-2 text-muted-foreground text-sm">
+                    <div className="h-4 w-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                    Loading component...
+                  </div>
+                }>
+                  <ActiveComponent key={`${reloadKey}-${activeCodeTab}`} />
+                </Suspense>
+
               </div>
             </TabsContent>
 
             {/* Code Panel */}
-            <TabsContent value="code"  className="data-[state=inactive]:hidden">
+            <TabsContent value="code" className="data-[state=inactive]:hidden">
               <div className="h-full overflow-y-auto p-4 space-y-8">
                 {componentCodeOriginal && componentCodeBase ? (
                   <div className="space-y-4">


### PR DESCRIPTION
## Description

In the component preview overlay toolbar, the header section (Preview/Code tabs, variant toggle, and action buttons) was getting visually compressed/squished at certain desktop breakpoints, specifically between approximately **1024px and 1110px**.

**Root cause**: The flex layout with `justify-between` allowed elements to shrink when the container width was tight, even though it looked fine below 1024px and above ~1110px.

**What I Improved**: 
- Added `shrink-0` to key flex children (TabsList, variant toggle, and actions group) to prevent unwanted compression.
- Made the "Open Full Page" link responsive: it now shows **"Open"** + icon in the problematic narrow range, and switches to **"Open Full Page"** at `min-[1120px]` and above.
- Improved spacing with better responsive gaps, padding and removed fixed right margins that were wasting space.

This results in a clean, non-squished layout across all breakpoints without horizontal overflow.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested locally with dev server by manually resizing the browser window across multiple widths:
  - 1000px – 1024px (mobile/desktop transition)
  - 1024px – 1110px (the previously problematic range)
  - 1120px – 1280px+ (wide desktop)
- Verified behavior both with and without the variant toggle enabled.
- Checked that tabs, buttons, and link text remain fully readable with no squishing or wrapping issues.

- [x] Tested locally with dev server
- [x] Checked against Lint & TypeScript errors

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Added new component/dashboard to registry and checked indexing numbers

**Screenshots** :

- Before: Screenshot at ~1070px showing the squished header

<img width="681" height="167" alt="Before Header - 1070px" src="https://github.com/user-attachments/assets/49f2b3ff-6b01-4349-ae3d-d4fbbc3e9f1b" />

- After: Screenshot at the same width showing the fixed layout

<img width="695" height="167" alt="After Header 1070px" src="https://github.com/user-attachments/assets/6f2fc74e-84ce-47a9-9ccd-b4fb65babd7a" />

