### PR TITLE
fix: improve card split accordian responsiveness on small screens

### DIFF
--- a/src/data/contents/components/card-split-accordian/base.tsx
+++ b/src/data/contents/components/card-split-accordian/base.tsx
@@ -152,7 +152,7 @@ const AccordionItem: FC<AccordionItemProps> = ({
             <div className="text-card-foreground flex items-center gap-[12px]">
               {item.icon}
 
-              <span className="text-card-foreground text-lg font-bold">
+              <span className="text-card-foreground text-sm sm:text-base lg:text-lg font-bold">
                 {item.title}
               </span>
             </div>
@@ -171,7 +171,7 @@ const AccordionItem: FC<AccordionItemProps> = ({
             className="overflow-hidden will-change-transform"
           >
             <div ref={ref}>
-              <div className="text-muted-foreground px-5 pb-5 text-[18px] font-medium">
+              <div className="text-muted-foreground px-5 pb-5 text-sm sm:text-base lg:text-[18px] font-medium">
                 {item.content}
               </div>
             </div>
@@ -190,7 +190,7 @@ export const AccordionApp: FC<AccordionProps> = ({ items }) => {
   const openIndex = defaultItems.findIndex((item) => item.id === openId);
 
   return (
-    <div className="theme-injected flex w-full flex-col items-center justify-center p-6 transition-colors duration-500">
+    <div className="theme-injected flex w-full flex-col items-center justify-center p-1 sm:p-6 transition-colors duration-500">
       <ul className="w-full max-w-[400px]">
         {defaultItems.map((item, index) => (
           <AccordionItem

--- a/src/data/contents/components/card-split-accordian/original.tsx
+++ b/src/data/contents/components/card-split-accordian/original.tsx
@@ -155,7 +155,7 @@ const AccordionItem: FC<AccordionItemProps> = ({
             <div className="flex items-center gap-[12px]">
               {item.icon}
 
-              <span className="text-lg font-bold text-[#272729] dark:text-zinc-100">
+              <span className="text-sm sm:text-base lg:text-lg font-bold text-[#272729] dark:text-zinc-100">
                 {item.title}
               </span>
             </div>
@@ -174,7 +174,7 @@ const AccordionItem: FC<AccordionItemProps> = ({
             className="overflow-hidden will-change-transform"
           >
             <div ref={ref}>
-              <div className="px-5 pb-5 text-[18px] font-medium text-[#545359] dark:text-zinc-400">
+              <div className="px-5 pb-5 text-sm sm:text-base lg:text-[18px] font-medium text-[#545359] dark:text-zinc-400">
                 {item.content}
               </div>
             </div>
@@ -193,7 +193,7 @@ export const AccordionApp: FC<AccordionProps> = ({ items }) => {
   const openIndex = defaultItems.findIndex((item) => item.id === openId);
 
   return (
-    <div className="flex w-full  flex-col items-center justify-center bg-[#ffffff] p-6 transition-colors duration-500 dark:bg-zinc-950">
+    <div className="flex w-full  flex-col items-center justify-center bg-[#ffffff] p-1 sm:p-6 transition-colors duration-500 dark:bg-zinc-950">
       <ul className="w-full max-w-[400px]">
         {defaultItems.map((item, index) => (
           <AccordionItem


### PR DESCRIPTION
## Description

Accordion text and spacing appeared oversized on smaller screens (~400px), affecting readability and overall layout balance.

This PR improves the responsive behavior of the Card Split Accordion component and fixes a layout issue in the component preview overlay.

Fixes # (issue)

### Changes made
- Added responsive typography for title and content
- Reduced padding for better spacing on smaller screens
- Ensured smoother scaling across breakpoints without affecting desktop layout

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
- Checked both **Original** and **Base** variants in collapsed and expanded states.
- [x] Tested locally with dev server
- [x] Checked against Lint & TypeScript errors

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Added new component/dashboard to registry and checked indexing numbers

## Screenshots

### Before
<img width="326" height="522" alt="Before Accordian" src="https://github.com/user-attachments/assets/4af7c0d3-8948-4fa4-b958-bfef28ccf388" />


### After
<img width="337" height="441" alt="After Accordian" src="https://github.com/user-attachments/assets/c665a326-ede7-4d3d-9dd5-7af35e0b44f4" />

