### PR TITLE
Update installation.tsx

### DIFF
--- a/src/pages/installation.tsx
+++ b/src/pages/installation.tsx
@@ -80,10 +80,10 @@ function ComponentInstallation() {
       <TabsContent value="cli" className="mt-0">
         <div className="space-y-4">
           <PackageTabs
-            npm="npx shadcn@latest add https://registry.watermelon.sh/r/card-split-accordian.json"
-            pnpm="pnpm dlx shadcn@latest add https://registry.watermelon.sh/r/card-split-accordian.json"
-            yarn="yarn dlx shadcn@latest add https://registry.watermelon.sh/r/card-split-accordian.json"
-            bun="bunx --bun shadcn@latest add https://registry.watermelon.sh/r/card-split-accordian.json"
+            npm="npx shadcn@latest add https://registry.watermelon.sh/r/card-split-accordion.json"
+            pnpm="pnpm dlx shadcn@latest add https://registry.watermelon.sh/r/card-split-accordion.json"
+            yarn="yarn dlx shadcn@latest add https://registry.watermelon.sh/r/card-split-accordion.json"
+            bun="bunx --bun shadcn@latest add https://registry.watermelon.sh/r/card-split-accordion.json"
           />
         </div>
       </TabsContent>


### PR DESCRIPTION
## Description

Fixed a spelling error in the `PackageTabs` component snippet for `card-split-accordion`. The JSON file path incorrectly had `accordian` instead of `accordion`, which would cause package managers (npm, pnpm, yarn, bun) to fail when users tried to download the component via the CLI. 

Fixes # (Leave blank or add issue number if one is open, e.g., `#123`)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Checked against Lint & TypeScript errors
- [ ] Tested locally with dev server

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Added new component/dashboard to registry and checked indexing numbers
