### PR TITLE
feat:new variant of card component added

### DIFF
--- a/src/data/contents/blocks/bento/bento-2/bento-2.mdx
+++ b/src/data/contents/blocks/bento/bento-2/bento-2.mdx
@@ -1,7 +1,6 @@
 ---
 title: Bento-2
 slug: bento-2
-category: bento
 description: >-
   A low-light bento layout focused on property discovery, blending
   listing visuals, quick stats, and action-driven interface elements.

--- a/src/data/contents/components/card/index.ts
+++ b/src/data/contents/components/card/index.ts
@@ -14,6 +14,7 @@ import Card12 from "./variant-12";
 import Card13 from "./variant-13";
 import Card14 from "./variant-14";
 import Card15 from "./variant-15";
+import Card16 from "./variant-16";
 import code1 from "./variant-1.tsx?raw";
 import code2 from "./variant-2.tsx?raw";
 import code3 from "./variant-3.tsx?raw";
@@ -29,6 +30,7 @@ import code12 from "./variant-12.tsx?raw";
 import code13 from "./variant-13.tsx?raw";
 import code14 from "./variant-14.tsx?raw";
 import code15 from "./variant-15.tsx?raw";
+import code16 from "./variant-16.tsx?raw";
 import type { UiVariant } from "@/data/components-registry";
 
 export const variants: UiVariant[] = [
@@ -137,7 +139,14 @@ export const variants: UiVariant[] = [
     cli: "npx shadcn@latest add Card",
     code: code15,
     colSpan: 2,
-  }
+  },
+  {
+    id: "card-16",
+    title: "Card 16",
+    component: Card16,
+    cli: "npx shadcn@latest add https://registry.watermelon.sh/r/card-16.json",
+    code: code16,
+  },
 ];
 
 export { category };

--- a/src/data/contents/components/card/variant-16.tsx
+++ b/src/data/contents/components/card/variant-16.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/base-ui/card";
+import { ArrowLeft } from "lucide-react";
+import { Button } from '@/components/base-ui/button';
+
+type FeatureCardType = {
+    title: string,
+    description: string,
+    imageSrc: string,
+    imageAlt: string,
+}
+
+const featureCard: FeatureCardType = {
+    title: "Designed to Feel Effortless",
+    description: "This is what happens when design meets intention and taste.",
+    imageSrc: "https://images.unsplash.com/photo-1676293038838-c2e5e310c203?q=80&w=764&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    imageAlt: "A model in stylish pose",
+}
+
+const Card16 = () => {
+    return (
+        <Card className="max-w-md">
+            <img src={featureCard.imageSrc}
+                alt={featureCard.imageAlt}
+                className="rounded-lg m-3.5 md:m-4 object-cover" />
+
+            <CardHeader>
+                <CardTitle >{featureCard.title}</CardTitle>
+                <CardDescription>{featureCard.description}</CardDescription>
+            </CardHeader>
+
+            <CardContent className="flex w-full items-center justify-between mt-7">
+                <div className="flex items-center justify-center size-7 p-1 
+                bg-accent rounded-full border border-accent-foreground/10">
+                    <ArrowLeft className="size-4" />
+                </div>
+
+                <Button>
+                    Explore More
+                </Button>
+            </CardContent>
+        </Card >
+    );
+}
+
+export default Card16;


### PR DESCRIPTION
Hi there,

I have added a new variant (variant-16) inside card component. It is a feature card with a image on top and title and description below the image. Also have two buttons, one navigates to previous card (for example) and the other is "explore more" . Both buttons are just static for now.

Btw, this card is fully responsive across the screens .

Here is the screenshot of how it looks like.

<img width="1918" height="973" alt="Screenshot (1223)" src="https://github.com/user-attachments/assets/99a1e79f-ef91-40b7-ad89-377f81ed5263" />

Looking forward for your feedback.