### PR TITLE
Added jobtracker dashboard

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ui.watermelon.sh</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -80,157 +80,157 @@
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/accordian</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/action</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/buttons</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/cards</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/carousel</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/choice-chips</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/dialog</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/disclosure</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/dropdown</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/filters</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/inputs</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/interaction</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/lists</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/map</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/marketing</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/media</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/micro-interaction</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/navigation</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/pagination</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/popover</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/scheduler</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/sliders</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/tabs</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/toggle</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/tooltip</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/animated-components/category/widgets</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -2078,145 +2078,145 @@
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/Announcement</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/auth</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/Blog</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/Career</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/contact</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/CTA</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/Error</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/FAQ</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/Feature</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/file-upload</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/footer</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/hero</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/integrations</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/navigation</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/newsletter</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/notification</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/pricing</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/Stats</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/Team</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/testimonials</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/blocks/widget</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/changelog</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/components</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -2402,31 +2402,31 @@
   </url>
   <url>
     <loc>https://ui.watermelon.sh/copyright</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/framework-support</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/installation</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/privacy</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ui.watermelon.sh/terms</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/data/contents/dashboards/jobtracker-dashboard/assets/icons.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/assets/icons.tsx
@@ -1,0 +1,494 @@
+import type { SVGProps } from "react";
+
+type IconProps = SVGProps<SVGSVGElement>;
+
+export function CollapseIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M17.3994 4.36407C19.0563 4.36407 20.3994 5.70722 20.3994 7.36407V16.6365C20.3994 18.2934 19.0563 19.6365 17.3994 19.6365H6.59961C4.94276 19.6365 3.59961 18.2934 3.59961 16.6365V7.36407C3.59961 5.70722 4.94276 4.36407 6.59961 4.36407H17.3994ZM12.625 5.89142C11.5206 5.89158 10.6251 6.78704 10.625 7.89142V16.1102C10.6252 17.2145 11.5207 18.11 12.625 18.1102H16.7197C17.8242 18.1102 18.7195 17.2146 18.7197 16.1102V7.89142C18.7196 6.78694 17.8242 5.89142 16.7197 5.89142H12.625Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+export function CustomersIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M10.8337 9.16665C10.8337 7.3257 9.34124 5.83331 7.50033 5.83331C5.65938 5.83331 4.16699 7.3257 4.16699 9.16665C4.16699 11.0076 5.65938 12.5 7.50033 12.5C9.34124 12.5 10.8337 11.0076 10.8337 9.16665Z"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M9.19916 6.29811C9.17791 6.14623 9.16699 5.99106 9.16699 5.83333C9.16699 3.99238 10.6594 2.5 12.5003 2.5C14.3412 2.5 15.8337 3.99238 15.8337 5.83333C15.8337 7.67428 14.3412 9.16667 12.5003 9.16667C11.8798 9.16667 11.299 8.99717 10.8015 8.70192"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M12.5 17.5C12.5 14.7386 10.2614 12.5 7.5 12.5C4.73857 12.5 2.5 14.7386 2.5 17.5"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M17.5 14.1667C17.5 11.4053 15.2614 9.16669 12.5 9.16669"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function JobsIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M7.08301 5.41667C7.08301 4.24628 7.08301 3.66109 7.36389 3.24072C7.48549 3.05873 7.64174 2.90248 7.82372 2.78088C8.2441 2.5 8.82926 2.5 9.99967 2.5C11.1701 2.5 11.7553 2.5 12.1756 2.78088C12.3576 2.90248 12.5138 3.05873 12.6354 3.24072C12.9163 3.66109 12.9163 4.24628 12.9163 5.41667"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M18.3337 11.6667V11.25C18.3337 8.50019 18.3337 7.12523 17.4794 6.27096C16.6251 5.41669 15.2502 5.41669 12.5003 5.41669H7.50033C4.75047 5.41669 3.37553 5.41669 2.52127 6.27096C1.66699 7.12523 1.66699 8.50019 1.66699 11.25V11.6667C1.66699 14.4165 1.66699 15.7914 2.52127 16.6458C3.37553 17.5 4.75047 17.5 7.50033 17.5H12.5003C15.2502 17.5 16.6251 17.5 17.4794 16.6458C18.3337 15.7914 18.3337 14.4165 18.3337 11.6667Z"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M1.66699 8.33331C1.66699 8.33331 3.85998 11.6666 10.0003 11.6666C16.1407 11.6666 18.3337 8.33331 18.3337 8.33331"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M10 11.6667V13.3334"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function SettingsIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M12.9163 10C12.9163 11.6108 11.6105 12.9167 9.99967 12.9167C8.38884 12.9167 7.08301 11.6108 7.08301 10C7.08301 8.38918 8.38884 7.08334 9.99967 7.08334C11.6105 7.08334 12.9163 8.38918 12.9163 10Z"
+        stroke="currentColor"
+        strokeWidth="1.25"
+      />
+      <path
+        d="M17.5095 11.7471C17.9444 11.6299 18.1619 11.5712 18.2477 11.459C18.3337 11.347 18.3337 11.1665 18.3337 10.8058V9.19438C18.3337 8.83363 18.3337 8.65321 18.2477 8.54113C18.1618 8.42896 17.9444 8.3703 17.5095 8.25303C15.8842 7.8147 14.8669 6.11547 15.2864 4.50077C15.4017 4.0567 15.4594 3.83468 15.4043 3.70445C15.3492 3.57423 15.1912 3.4845 14.8751 3.30501L13.4378 2.48899C13.1277 2.31287 12.9726 2.22481 12.8334 2.24356C12.6942 2.26231 12.5372 2.41899 12.223 2.73232C11.007 3.94545 8.99499 3.9454 7.77894 2.73225C7.46485 2.4189 7.30781 2.26224 7.1686 2.24348C7.0294 2.22473 6.8743 2.31279 6.5641 2.4889L5.12686 3.30494C4.81077 3.4844 4.65272 3.57414 4.59764 3.70434C4.54256 3.83455 4.60022 4.0566 4.71553 4.50071C5.1348 6.11546 4.11676 7.81474 2.49118 8.25305C2.05626 8.3703 1.8388 8.42896 1.75289 8.54105C1.66699 8.65321 1.66699 8.83363 1.66699 9.19438V10.8058C1.66699 11.1665 1.66699 11.347 1.75289 11.459C1.83878 11.5712 2.05625 11.6299 2.49118 11.7471C4.11649 12.1855 5.13373 13.8847 4.71426 15.4994C4.5989 15.9435 4.54122 16.1655 4.59629 16.2957C4.65138 16.426 4.80943 16.5157 5.12553 16.6951L6.56278 17.5112C6.873 17.6873 7.02811 17.7754 7.16733 17.7566C7.30654 17.7379 7.46356 17.5811 7.77758 17.2678C8.99424 16.0537 11.0077 16.0536 12.2244 17.2677C12.5384 17.5811 12.6954 17.7378 12.8347 17.7565C12.9738 17.7753 13.129 17.6872 13.4392 17.5111L14.8764 16.695C15.1926 16.5156 15.3507 16.4259 15.4057 16.2956C15.4607 16.1654 15.4031 15.9434 15.2877 15.4993C14.868 13.8847 15.8844 12.1855 17.5095 11.7471Z"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export function LogoutIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M3.66023 3.33405C3.33301 3.84663 3.33301 4.5097 3.33301 5.83585V14.1642C3.33301 15.4902 3.33301 16.1533 3.66023 16.6659C3.71867 16.7575 3.78417 16.8443 3.85615 16.9257C4.25921 17.381 4.89689 17.5632 6.17226 17.9275C7.45084 18.2927 8.09014 18.4753 8.55301 18.2014C8.63334 18.1539 8.70801 18.0976 8.77576 18.0335C9.16634 17.6637 9.16634 16.999 9.16634 15.6695V4.3305C9.16634 3.001 9.16634 2.33625 8.77576 1.9665C8.70801 1.90239 8.63334 1.84605 8.55301 1.79855C8.09014 1.52462 7.45084 1.70724 6.17226 2.07248C4.89689 2.4368 4.25921 2.61897 3.85615 3.07436C3.78417 3.15569 3.71867 3.24251 3.66023 3.33405Z"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M9.16699 3.33334H10.8479C12.4327 3.33334 13.225 3.33334 13.7173 3.8215C13.9918 4.09366 14.1132 4.45829 14.167 5.00001M9.16699 16.6667H10.8479C12.4327 16.6667 13.225 16.6667 13.7173 16.1785C13.9918 15.9063 14.1132 15.5418 14.167 15"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M17.5003 10H11.667M16.2503 7.91666C16.2503 7.91666 18.3337 9.45104 18.3337 10C18.3337 10.549 16.2503 12.0833 16.2503 12.0833"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function BackIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M15 6C15 6 9.00001 10.4189 9 12C8.99999 13.5812 15 18 15 18"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function ForwardIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <g opacity="0.5">
+        <path
+          d="M9.00005 6C9.00005 6 15 10.4189 15 12C15 13.5812 9 18 9 18"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </g>
+    </svg>
+  );
+}
+
+export function NotificationIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M12.9163 15C12.9163 16.6108 11.6105 17.9167 9.99967 17.9167C8.38884 17.9167 7.08301 16.6108 7.08301 15"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M16.0259 15H3.97406C3.15996 15 2.5 14.34 2.5 13.5259C2.5 13.135 2.6553 12.7601 2.93174 12.4836L3.43443 11.9809C3.90327 11.5121 4.16667 10.8761 4.16667 10.2131V7.91665C4.16667 4.69499 6.77834 2.08331 10 2.08331C13.2217 2.08331 15.8333 4.69498 15.8333 7.91665V10.2131C15.8333 10.8761 16.0967 11.5121 16.5656 11.9809L17.0682 12.4836C17.3447 12.7601 17.5 13.135 17.5 13.5259C17.5 14.34 16.84 15 16.0259 15Z"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function MenuIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M12 6.00003C12 6.00003 9.05407 10 8 10C6.94587 10 4 6 4 6"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function SearchIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M14.167 14.1667L17.5003 17.5"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M15.8333 9.16667C15.8333 5.48477 12.8486 2.5 9.16667 2.5C5.48477 2.5 2.5 5.48477 2.5 9.16667C2.5 12.8486 5.48477 15.8333 9.16667 15.8333C12.8486 15.8333 15.8333 12.8486 15.8333 9.16667Z"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function AddIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M17.5 10C17.5 10.1658 17.4342 10.3247 17.3169 10.4419C17.1997 10.5592 17.0408 10.625 16.875 10.625H10.625V16.875C10.625 17.0408 10.5592 17.1997 10.4419 17.3169C10.3247 17.4342 10.1658 17.5 10 17.5C9.83424 17.5 9.67527 17.4342 9.55806 17.3169C9.44085 17.1997 9.375 17.0408 9.375 16.875V10.625H3.125C2.95924 10.625 2.80027 10.5592 2.68306 10.4419C2.56585 10.3247 2.5 10.1658 2.5 10C2.5 9.83424 2.56585 9.67527 2.68306 9.55806C2.80027 9.44085 2.95924 9.375 3.125 9.375H9.375V3.125C9.375 2.95924 9.44085 2.80027 9.55806 2.68306C9.67527 2.56585 9.83424 2.5 10 2.5C10.1658 2.5 10.3247 2.56585 10.4419 2.68306C10.5592 2.80027 10.625 2.95924 10.625 3.125V9.375H16.875C17.0408 9.375 17.1997 9.44085 17.3169 9.55806C17.4342 9.67527 17.5 9.83424 17.5 10Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+export function EditIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M14.0737 3.88545C14.8189 3.07808 15.1915 2.6744 15.5874 2.43893C16.5427 1.87076 17.7191 1.85309 18.6904 2.39232C19.0929 2.6158 19.4769 3.00812 20.245 3.79276C21.0131 4.5774 21.3972 4.96972 21.6159 5.38093C22.1438 6.37312 22.1265 7.57479 21.5703 8.5507C21.3398 8.95516 20.9446 9.33578 20.1543 10.097L10.7506 19.1543C9.25288 20.5969 8.504 21.3182 7.56806 21.6837C6.63212 22.0493 5.6032 22.0224 3.54536 21.9686L3.26538 21.9613C2.63891 21.9449 2.32567 21.9367 2.14359 21.73C1.9615 21.5234 1.98636 21.2043 2.03608 20.5662L2.06308 20.2197C2.20301 18.4235 2.27297 17.5255 2.62371 16.7182C2.97444 15.9109 3.57944 15.2555 4.78943 13.9445L14.0737 3.88545Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M13 4L20 11"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M14 22H22"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function DeleteIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M19.5 5.5L18.8803 15.5251C18.7219 18.0864 18.6428 19.3671 18.0008 20.2879C17.6833 20.7431 17.2747 21.1273 16.8007 21.416C15.8421 22 14.559 22 11.9927 22C9.42312 22 8.1383 22 7.17905 21.4149C6.7048 21.1257 6.296 20.7408 5.97868 20.2848C5.33688 19.3626 5.25945 18.0801 5.10461 15.5152L4.5 5.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M3 5.5H21M16.0557 5.5L15.3731 4.09173C14.9196 3.15626 14.6928 2.68852 14.3017 2.39681C14.215 2.3321 14.1231 2.27454 14.027 2.2247C13.5939 2 13.0741 2 12.0345 2C10.9688 2 10.436 2 9.99568 2.23412C9.8981 2.28601 9.80498 2.3459 9.71729 2.41317C9.32164 2.7167 9.10063 3.20155 8.65861 4.17126L8.05292 5.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M9.5 16.5V10.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M14.5 16.5V10.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export function JobDraftIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 12 12"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M7.60705 2.99119L8.3079 2.29031C8.695 1.90323 9.3226 1.90323 9.7097 2.29031C10.0967 2.6774 10.0967 3.30499 9.7097 3.69207L9.0088 4.39295M7.60705 2.99119L3.49011 7.10815C2.96746 7.6308 2.70613 7.8921 2.52818 8.21055C2.35023 8.529 2.1712 9.28095 2 10C2.71904 9.8288 3.47099 9.64975 3.78944 9.4718C4.10789 9.29385 4.36922 9.03255 4.89187 8.5099L9.0088 4.39295M7.60705 2.99119L9.0088 4.39295"
+        stroke="currentColor"
+        strokeWidth="0.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M5.5 10H8.5"
+        stroke="currentColor"
+        strokeWidth="0.75"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export function JobActiveIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 12 12"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M4.31407 6.3368H4.08459C3.34272 6.3368 2.97179 6.3368 2.81368 6.0922C2.65557 5.84765 2.80622 5.5069 3.10752 4.82542L4.01334 2.77661C4.28728 2.157 4.42426 1.84719 4.68998 1.67359C4.95571 1.5 5.29295 1.5 5.9675 1.5H7.0122C7.8316 1.5 8.2413 1.5 8.3958 1.76768C8.55035 2.03535 8.3471 2.39294 7.94055 3.10811L7.4046 4.05094C7.2025 4.40648 7.10145 4.58425 7.10285 4.72976C7.1047 4.91888 7.20525 5.0931 7.3677 5.1885C7.4927 5.26195 7.69635 5.26195 8.1037 5.26195C8.61865 5.26195 8.87615 5.26195 9.01025 5.3511C9.18445 5.4669 9.27565 5.6741 9.2437 5.8816C9.2191 6.0413 9.0459 6.2328 8.6995 6.61585L5.93195 9.67615C5.38835 10.2773 5.11655 10.5778 4.93403 10.4827C4.75151 10.3876 4.83916 9.9911 5.01445 9.1981L5.35785 7.6448C5.4913 7.041 5.55805 6.7391 5.39755 6.53795C5.23705 6.3368 4.92938 6.3368 4.31407 6.3368Z"
+        stroke="currentColor"
+        strokeWidth="0.75"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function JobCustomerIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 18 18"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M12.75 6.375C12.75 4.30393 11.071 2.625 9 2.625C6.92893 2.625 5.25 4.30393 5.25 6.375C5.25 8.44605 6.92893 10.125 9 10.125C11.071 10.125 12.75 8.44605 12.75 6.375Z"
+        fill="currentColor"
+      />
+      <path
+        d="M14.25 15.375C14.25 12.4755 11.8995 10.125 9 10.125C6.10051 10.125 3.75 12.4755 3.75 15.375H14.25Z"
+        fill="currentColor"
+        stroke="currentColor"
+        strokeWidth="1.125"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function JobLocationIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 18 18"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M10.2133 16.0252C9.88807 16.3297 9.4533 16.5 9.00082 16.5C8.54835 16.5 8.11365 16.3297 7.78838 16.0252C4.80977 13.2195 0.81807 10.0852 2.7647 5.53474C3.81722 3.07437 6.34375 1.5 9.00082 1.5C11.6579 1.5 14.1845 3.07437 15.237 5.53474C17.1812 10.0795 13.1992 13.2292 10.2133 16.0252Z"
+        fill="currentColor"
+      />
+      <path
+        d="M11.625 8.25C11.625 9.69975 10.4497 10.875 9 10.875C7.55025 10.875 6.375 9.69975 6.375 8.25C6.375 6.80025 7.55025 5.625 9 5.625C10.4497 5.625 11.625 6.80025 11.625 8.25Z"
+        stroke="var(--card)"
+        strokeWidth="1.25"
+      />
+    </svg>
+  );
+}
+
+export function JobTimeIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 18 18"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M9 16.5C13.1421 16.5 16.5 13.1421 16.5 9C16.5 4.85786 13.1421 1.5 9 1.5C4.85786 1.5 1.5 4.85786 1.5 9C1.5 13.1421 4.85786 16.5 9 16.5Z"
+        fill="currentColor"
+      />
+      <path
+        d="M9 6V9L10.5 10.5"
+        stroke="var(--card)"
+        strokeWidth="1.125"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/data/contents/dashboards/jobtracker-dashboard/assets/logo.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/assets/logo.tsx
@@ -1,0 +1,21 @@
+import type { SVGProps } from "react";
+
+export function Logo(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 40 40"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M24 0H16V12.0632C15.9663 14.2434 14.1885 16 12.0005 16H0V24H8.68629C10.808 24 12.8429 23.1571 14.3431 21.6569L21.6569 14.3431C23.1571 12.8429 24 10.808 24 8.68629V0Z"
+        fill="currentColor"
+      />
+      <path
+        d="M16 40H24V27.9368C24.0337 25.7566 25.8115 24 27.9995 24H40V16H31.3137C29.192 16 27.1571 16.8429 25.6569 18.3431L18.3431 25.6569C16.8429 27.1571 16 29.192 16 31.3137V40Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/dashboard/customers-content.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/dashboard/customers-content.tsx
@@ -1,0 +1,186 @@
+import { useState } from "react";
+import { EllipsisVertical, Pencil, Trash2 } from "lucide-react";
+
+import { AddIcon, SearchIcon } from "../../assets/icons";
+import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
+import { Button } from "../ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+import { Input } from "../ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../ui/table";
+import { customers } from "../../data";
+
+export function CustomersContent() {
+  return (
+    <section className="@container min-w-0 px-4 pt-4 pb-4 sm:px-6 sm:pt-7 sm:pb-6 lg:px-10 lg:pb-10">
+      <div className="flex flex-col gap-4 sm:gap-6 @4xl:flex-row @4xl:items-center @4xl:justify-between">
+        <div className="flex items-center justify-between gap-3 @4xl:shrink-0">
+          <h1 className="text-xl font-semibold tracking-tight sm:text-3xl">
+            Customers
+          </h1>
+          <Button className="h-10 rounded-lg px-3 sm:hidden">
+            Add
+            <AddIcon className="size-4" />
+          </Button>
+        </div>
+        <div className="flex w-full flex-col gap-2 sm:flex-row @4xl:w-auto">
+          <div className="relative min-w-0 flex-1 sm:mr-auto sm:max-w-80 lg:max-w-96 @4xl:mr-0 @4xl:w-96 @4xl:flex-none">
+            <SearchIcon className="absolute top-1/2 left-3 size-5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              className="h-11 rounded-xl border-0 bg-muted pl-10 shadow-none md:text-base"
+              placeholder="Search by name, email, or phone…"
+              aria-label="Search customers"
+            />
+          </div>
+          <Button
+            size="lg"
+            className="hidden h-11 rounded-xl px-4 text-base sm:inline-flex"
+          >
+            Add Customer
+            <AddIcon className="size-5" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-6 sm:mt-8">
+        <CustomerTable />
+      </div>
+    </section>
+  );
+}
+
+const headerClassName =
+  "h-12 px-4 text-sm font-normal text-muted-foreground first:rounded-l-xl last:rounded-r-xl";
+const cellClassName = "px-4 py-0";
+
+function CustomerActions({
+  name,
+  onDelete,
+}: {
+  name: string;
+  onDelete: () => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon-lg"
+            className="rounded-full text-muted-foreground"
+            aria-label={`Actions for ${name}`}
+          >
+            <EllipsisVertical className="size-5" />
+          </Button>
+        }
+      />
+      <DropdownMenuContent align="end" className="w-36">
+        <DropdownMenuItem>
+          <Pencil />
+          Edit
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant="destructive" onClick={onDelete}>
+          <Trash2 />
+          Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function CustomerTable() {
+  const [customerRows, setCustomerRows] = useState(customers);
+
+  return (
+    <Table
+      containerClassName="overscroll-x-contain"
+      className="min-w-[46rem] table-fixed text-sm sm:text-base"
+    >
+      <colgroup>
+        <col className="w-[27%]" />
+        <col className="w-[35%]" />
+        <col className="w-[28%]" />
+        <col className="w-[10%]" />
+      </colgroup>
+      <TableHeader className="[&_tr]:border-0">
+        <TableRow className="bg-muted hover:bg-muted!">
+          <TableHead className={headerClassName}>Name</TableHead>
+          <TableHead className={headerClassName}>Email</TableHead>
+          <TableHead className={headerClassName}>Phone</TableHead>
+          <TableHead className={`${headerClassName} text-center`}>
+            Action
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {customerRows.map((customer) => (
+          <TableRow
+            key={customer.email}
+            className="h-16 hover:bg-transparent! has-aria-expanded:bg-transparent!"
+          >
+            <TableCell className={cellClassName}>
+              <div className="flex min-w-0 items-center gap-3">
+                <Avatar className="size-8">
+                  <AvatarImage src={customer.avatar} alt="" />
+                  <AvatarFallback>{customer.name.slice(0, 2)}</AvatarFallback>
+                </Avatar>
+                <span className="truncate font-medium">{customer.name}</span>
+              </div>
+            </TableCell>
+            <TableCell className={cellClassName}>
+              <a
+                className="block truncate text-muted-foreground hover:text-foreground"
+                href={`mailto:${customer.email}`}
+              >
+                {customer.email}
+              </a>
+            </TableCell>
+            <TableCell
+              className={`${cellClassName} text-muted-foreground tabular-nums`}
+            >
+              <a
+                className="hover:text-foreground"
+                href={`tel:${customer.phone.replace(/\s/g, "")}`}
+              >
+                {customer.phone}
+              </a>
+            </TableCell>
+            <TableCell className={`${cellClassName} text-center`}>
+              <CustomerActions
+                name={customer.name}
+                onDelete={() =>
+                  setCustomerRows((current) =>
+                    current.filter(({ email }) => email !== customer.email),
+                  )
+                }
+              />
+            </TableCell>
+          </TableRow>
+        ))}
+        {customerRows.length === 0 && (
+          <TableRow className="hover:bg-transparent!">
+            <TableCell
+              colSpan={4}
+              className="h-32 px-4 text-center text-muted-foreground"
+            >
+              No customers found.
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/dashboard/job-details/estimates-content.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/dashboard/job-details/estimates-content.tsx
@@ -1,0 +1,751 @@
+import { useState, type CSSProperties } from "react";
+import {
+  closestCenter,
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type CollisionDetection,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  ChevronDown,
+  ChevronsUpDown,
+  Copy,
+  EllipsisVertical,
+  GripVertical,
+  Pencil,
+  Trash2,
+} from "lucide-react";
+
+import { AddIcon } from "../../../assets/icons";
+import { Button } from "../../ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../../ui/dropdown-menu";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../../ui/table";
+import type { EstimateLineItem, EstimateSection } from "../../../data";
+import { cn } from "../../../lib/utils";
+
+type EstimatesContentProps = {
+  sections: EstimateSection[];
+};
+
+type SortDirection = "none" | "ascending" | "descending";
+
+type SortableRowData =
+  | {
+      type: "section";
+      sectionId: string;
+      number: string;
+      label: string;
+    }
+  | {
+      type: "item";
+      sectionId: string;
+      itemId: string;
+      number: string;
+      label: string;
+    };
+
+const columnCount = 10;
+const estimateUnits = ["LS", "EA", "HR", "SF"] as const;
+const tableHeaderClassName =
+  "h-12 px-4 text-sm font-normal text-muted-foreground first:rounded-l-xl last:rounded-r-xl";
+const tableCellClassName = "px-4 py-0";
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+const matchingRowCollision: CollisionDetection = (args) => {
+  const activeType = args.active.data.current?.type;
+  const matchingContainers = args.droppableContainers.filter(
+    (container) => container.data.current?.type === activeType,
+  );
+
+  return closestCenter({
+    ...args,
+    droppableContainers: matchingContainers,
+  });
+};
+
+export function EstimatesContent({ sections }: EstimatesContentProps) {
+  const [estimateSections, setEstimateSections] = useState(sections);
+  const [collapsedSectionIds, setCollapsedSectionIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [sortDirection, setSortDirection] =
+    useState<SortDirection>("none");
+  const [activeRow, setActiveRow] = useState<SortableRowData | null>(null);
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 6 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  function toggleSection(sectionId: string) {
+    setCollapsedSectionIds((current) => {
+      const next = new Set(current);
+      if (next.has(sectionId)) {
+        next.delete(sectionId);
+      } else {
+        next.add(sectionId);
+      }
+      return next;
+    });
+  }
+
+  function sortByName() {
+    const nextDirection =
+      sortDirection === "ascending" ? "descending" : "ascending";
+    const multiplier = nextDirection === "ascending" ? 1 : -1;
+
+    setEstimateSections((current) =>
+      current.map((section) => ({
+        ...section,
+        items: [...section.items].sort(
+          (a, b) => a.name.localeCompare(b.name) * multiplier,
+        ),
+      })),
+    );
+    setSortDirection(nextDirection);
+  }
+
+  function updateItemUnit(sectionId: string, itemId: string, unit: string) {
+    setEstimateSections((current) =>
+      current.map((section) =>
+        section.id === sectionId
+          ? {
+              ...section,
+              items: section.items.map((item) =>
+                item.id === itemId ? { ...item, unit } : item,
+              ),
+            }
+          : section,
+      ),
+    );
+  }
+
+  function addLineItem(sectionId: string) {
+    const newItem: EstimateLineItem = {
+      id: crypto.randomUUID(),
+      name: "New line item",
+      quantity: 1,
+      unit: "LS",
+      unitCost: 0,
+      marginPercent: 0,
+    };
+
+    setEstimateSections((current) =>
+      current.map((section) =>
+        section.id === sectionId
+          ? { ...section, items: [...section.items, newItem] }
+          : section,
+      ),
+    );
+    setCollapsedSectionIds((current) => {
+      const next = new Set(current);
+      next.delete(sectionId);
+      return next;
+    });
+    setSortDirection("none");
+  }
+
+  function duplicateLineItem(sectionId: string, itemId: string) {
+    setEstimateSections((current) =>
+      current.map((section) => {
+        if (section.id !== sectionId) {
+          return section;
+        }
+
+        const itemIndex = section.items.findIndex(({ id }) => id === itemId);
+        const sourceItem = section.items[itemIndex];
+        if (!sourceItem) {
+          return section;
+        }
+
+        const duplicate: EstimateLineItem = {
+          ...sourceItem,
+          id: crypto.randomUUID(),
+          name: `${sourceItem.name} copy`,
+        };
+        const nextItems = [...section.items];
+        nextItems.splice(itemIndex + 1, 0, duplicate);
+
+        return { ...section, items: nextItems };
+      }),
+    );
+    setSortDirection("none");
+  }
+
+  function deleteLineItem(sectionId: string, itemId: string) {
+    setEstimateSections((current) =>
+      current.map((section) =>
+        section.id === sectionId
+          ? {
+              ...section,
+              items: section.items.filter(({ id }) => id !== itemId),
+            }
+          : section,
+      ),
+    );
+    setSortDirection("none");
+  }
+
+  function handleDragStart(event: DragStartEvent) {
+    setActiveRow(event.active.data.current as SortableRowData);
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    const activeData = event.active.data.current as
+      | SortableRowData
+      | undefined;
+    const overData = event.over?.data.current as SortableRowData | undefined;
+
+    setActiveRow(null);
+
+    if (!activeData || !overData || event.active.id === event.over?.id) {
+      return;
+    }
+
+    if (activeData.type === "section" && overData.type === "section") {
+      setEstimateSections((current) => {
+        const oldIndex = current.findIndex(
+          ({ id }) => id === activeData.sectionId,
+        );
+        const newIndex = current.findIndex(
+          ({ id }) => id === overData.sectionId,
+        );
+        return arrayMove(current, oldIndex, newIndex);
+      });
+      setSortDirection("none");
+      return;
+    }
+
+    if (
+      activeData.type === "item" &&
+      overData.type === "item" &&
+      activeData.sectionId === overData.sectionId
+    ) {
+      setEstimateSections((current) =>
+        current.map((section) => {
+          if (section.id !== activeData.sectionId) {
+            return section;
+          }
+
+          const oldIndex = section.items.findIndex(
+            ({ id }) => id === activeData.itemId,
+          );
+          const newIndex = section.items.findIndex(
+            ({ id }) => id === overData.itemId,
+          );
+
+          return {
+            ...section,
+            items: arrayMove(section.items, oldIndex, newIndex),
+          };
+        }),
+      );
+      setSortDirection("none");
+    }
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={matchingRowCollision}
+      modifiers={[restrictToVerticalAxis]}
+      onDragStart={handleDragStart}
+      onDragCancel={() => setActiveRow(null)}
+      onDragEnd={handleDragEnd}
+    >
+      <Table
+        containerClassName="overscroll-x-contain"
+        className="min-w-[56rem] table-fixed text-sm sm:text-base"
+      >
+        <colgroup>
+          <col className="w-[8%]" />
+          <col className="w-[15%]" />
+          <col className="w-[11%]" />
+          <col className="w-[15%]" />
+          <col className="w-[7%]" />
+          <col className="w-[8%]" />
+          <col className="w-[11%]" />
+          <col className="w-[8%]" />
+          <col className="w-[9%]" />
+          <col className="w-[8%]" />
+        </colgroup>
+        <TableHeader className="[&_tr]:border-0">
+          <TableRow className="bg-muted hover:bg-muted!">
+            <TableHead className={tableHeaderClassName}>#</TableHead>
+            <TableHead
+              aria-sort={sortDirection}
+              className={tableHeaderClassName}
+            >
+              <Button
+                variant="ghost"
+                size="sm"
+                className="-ml-2 h-8 px-2 font-normal text-muted-foreground hover:bg-transparent"
+                onClick={sortByName}
+                aria-label={`Sort by name ${
+                  sortDirection === "ascending" ? "descending" : "ascending"
+                }`}
+              >
+                Name
+                <ChevronsUpDown className="size-4" />
+              </Button>
+            </TableHead>
+            <TableHead className={tableHeaderClassName}>CSI Code</TableHead>
+            <TableHead className={tableHeaderClassName}>Description</TableHead>
+            <TableHead className={cn(tableHeaderClassName, "text-right")}>
+              Qty
+            </TableHead>
+            <TableHead className={tableHeaderClassName}>Unit</TableHead>
+            <TableHead className={cn(tableHeaderClassName, "text-right")}>
+              Unit Cost
+            </TableHead>
+            <TableHead className={cn(tableHeaderClassName, "text-right")}>
+              Margin
+            </TableHead>
+            <TableHead className={cn(tableHeaderClassName, "text-right")}>
+              Profit
+            </TableHead>
+            <TableHead className={cn(tableHeaderClassName, "text-center")}>
+              Action
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+
+        <SortableContext
+          items={estimateSections.map(({ id }) => sectionSortableId(id))}
+          strategy={verticalListSortingStrategy}
+        >
+          {estimateSections.map((section, sectionIndex) => (
+            <SortableEstimateSection
+              key={section.id}
+              section={section}
+              sectionIndex={sectionIndex}
+              collapsed={collapsedSectionIds.has(section.id)}
+              onToggle={() => toggleSection(section.id)}
+              onAddItem={() => addLineItem(section.id)}
+              onUnitChange={(itemId, unit) =>
+                updateItemUnit(section.id, itemId, unit)
+              }
+              onDuplicateItem={(itemId) =>
+                duplicateLineItem(section.id, itemId)
+              }
+              onDeleteItem={(itemId) =>
+                deleteLineItem(section.id, itemId)
+              }
+            />
+          ))}
+        </SortableContext>
+      </Table>
+
+      <DragOverlay dropAnimation={{ duration: 200, easing: "ease-out" }}>
+        {activeRow ? <EstimateDragPreview row={activeRow} /> : null}
+      </DragOverlay>
+    </DndContext>
+  );
+}
+
+type SortableEstimateSectionProps = {
+  section: EstimateSection;
+  sectionIndex: number;
+  collapsed: boolean;
+  onToggle: () => void;
+  onAddItem: () => void;
+  onUnitChange: (itemId: string, unit: string) => void;
+  onDuplicateItem: (itemId: string) => void;
+  onDeleteItem: (itemId: string) => void;
+};
+
+function SortableEstimateSection({
+  section,
+  sectionIndex,
+  collapsed,
+  onToggle,
+  onAddItem,
+  onUnitChange,
+  onDuplicateItem,
+  onDeleteItem,
+}: SortableEstimateSectionProps) {
+  const sectionNumber = sectionIndex + 1;
+  const nextLineNumber = `${sectionNumber}.${section.items.length + 1}`;
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: sectionSortableId(section.id),
+    data: {
+      type: "section",
+      sectionId: section.id,
+      number: String(sectionNumber),
+      label: section.name,
+    } satisfies SortableRowData,
+  });
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    position: "relative",
+    zIndex: isDragging ? 1 : undefined,
+  };
+
+  return (
+    <TableBody
+      ref={setNodeRef}
+      style={style}
+      className={cn(isDragging && "opacity-35")}
+    >
+      <TableRow
+        aria-hidden="true"
+        className="h-3 border-0 hover:bg-transparent!"
+      >
+        <TableCell className="p-0" colSpan={columnCount} />
+      </TableRow>
+      <TableRow
+        className="cursor-pointer border-0 bg-muted/70 hover:bg-muted/70!"
+        role="button"
+        tabIndex={0}
+        aria-expanded={!collapsed}
+        aria-label={`${collapsed ? "Expand" : "Collapse"} ${
+          section.name
+        } section`}
+        onClick={onToggle}
+        onKeyDown={(event) => {
+          if (
+            event.target === event.currentTarget &&
+            (event.key === "Enter" || event.key === " ")
+          ) {
+            event.preventDefault();
+            onToggle();
+          }
+        }}
+      >
+        <TableCell className="h-12 rounded-l-xl px-4 py-0">
+          <span className="flex items-center gap-1">
+            <button
+              ref={setActivatorNodeRef}
+              type="button"
+              className="flex size-7 shrink-0 cursor-grab touch-none items-center justify-center rounded-md text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
+              {...attributes}
+              {...listeners}
+              onClick={(event) => event.stopPropagation()}
+              aria-label={`Reorder ${section.name} section`}
+            >
+              <GripVertical className="size-5" />
+            </button>
+            <span className="font-medium tabular-nums">{sectionNumber}</span>
+          </span>
+        </TableCell>
+        <TableCell
+          className="h-12 rounded-r-xl px-4 py-0 font-semibold"
+          colSpan={columnCount - 1}
+        >
+          <span className="flex items-center justify-between gap-4">
+            <span className="truncate">{section.name}</span>
+            <span
+              className="flex size-6 shrink-0 items-center justify-center"
+              aria-hidden="true"
+            >
+              <ChevronDown
+                className={cn(
+                  "size-4 transition-transform",
+                  collapsed && "-rotate-90",
+                )}
+              />
+            </span>
+          </span>
+        </TableCell>
+      </TableRow>
+
+      {!collapsed && (
+        <SortableContext
+          items={section.items.map(({ id }) =>
+            itemSortableId(section.id, id),
+          )}
+          strategy={verticalListSortingStrategy}
+        >
+          {section.items.map((item, itemIndex) => (
+            <SortableEstimateItemRow
+              key={item.id}
+              item={item}
+              sectionId={section.id}
+              number={`${sectionNumber}.${itemIndex + 1}`}
+              onUnitChange={(unit) => onUnitChange(item.id, unit)}
+              onDuplicate={() => onDuplicateItem(item.id)}
+              onDelete={() => onDeleteItem(item.id)}
+            />
+          ))}
+        </SortableContext>
+      )}
+
+      {!collapsed && (
+        <TableRow className="h-16 hover:bg-transparent!">
+          <TableCell
+            className={cn(
+              tableCellClassName,
+              "font-medium text-muted-foreground tabular-nums",
+            )}
+          >
+            {nextLineNumber}
+          </TableCell>
+          <TableCell className={tableCellClassName} colSpan={columnCount - 1}>
+            <Button
+              variant="link"
+              size="sm"
+              className="px-0"
+              onClick={onAddItem}
+            >
+              Add line item
+              <AddIcon className="size-4" />
+            </Button>
+          </TableCell>
+        </TableRow>
+      )}
+    </TableBody>
+  );
+}
+
+type SortableEstimateItemRowProps = {
+  item: EstimateLineItem;
+  sectionId: string;
+  number: string;
+  onUnitChange: (unit: string) => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+};
+
+function SortableEstimateItemRow({
+  item,
+  sectionId,
+  number,
+  onUnitChange,
+  onDuplicate,
+  onDelete,
+}: SortableEstimateItemRowProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: itemSortableId(sectionId, item.id),
+    data: {
+      type: "item",
+      sectionId,
+      itemId: item.id,
+      number,
+      label: item.name,
+    } satisfies SortableRowData,
+  });
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    position: "relative",
+    zIndex: isDragging ? 2 : undefined,
+  };
+
+  return (
+    <TableRow
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "h-16 hover:bg-transparent! has-aria-expanded:bg-transparent!",
+        isDragging && "opacity-35",
+      )}
+    >
+      <TableCell className={tableCellClassName}>
+        <span className="flex items-center gap-1">
+          <button
+            ref={setActivatorNodeRef}
+            type="button"
+            className="flex size-7 shrink-0 cursor-grab touch-none items-center justify-center rounded-md text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
+            {...attributes}
+            {...listeners}
+            aria-label={`Reorder ${item.name} line item`}
+          >
+            <GripVertical className="size-5" />
+          </button>
+          <span className="font-medium tabular-nums">{number}</span>
+        </span>
+      </TableCell>
+      <TableCell className={cn(tableCellClassName, "font-medium")}>
+        {item.name}
+      </TableCell>
+      <TableCell className={cn(tableCellClassName, "text-muted-foreground")}>
+        {item.csiCode ?? "Not set"}
+      </TableCell>
+      <TableCell
+        className={cn(tableCellClassName, "truncate text-muted-foreground")}
+        title={item.description}
+      >
+        {item.description ?? "No description"}
+      </TableCell>
+      <TableCell
+        className={cn(tableCellClassName, "text-right tabular-nums")}
+      >
+        {item.quantity.toFixed(2)}
+      </TableCell>
+      <TableCell className={tableCellClassName}>
+        <Select
+          value={item.unit}
+          onValueChange={(unit) => unit && onUnitChange(unit)}
+        >
+          <SelectTrigger
+            size="sm"
+            className="-mx-2 w-18 border-transparent bg-transparent shadow-none hover:bg-muted"
+            aria-label={`Unit for ${item.name}`}
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent align="start" className="min-w-20">
+            {estimateUnits.map((unit) => (
+              <SelectItem key={unit} value={unit}>
+                {unit}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </TableCell>
+      <TableCell
+        className={cn(tableCellClassName, "text-right tabular-nums")}
+      >
+        {currencyFormatter.format(item.unitCost)}
+      </TableCell>
+      <TableCell
+        className={cn(tableCellClassName, "text-right tabular-nums")}
+      >
+        {item.marginPercent}%
+      </TableCell>
+      <TableCell
+        className={cn(
+          tableCellClassName,
+          "text-right font-medium tabular-nums",
+        )}
+      >
+        {currencyFormatter.format(calculateProfit(item))}
+      </TableCell>
+      <TableCell className={cn(tableCellClassName, "text-center")}>
+        <LineItemActions
+          itemName={item.name}
+          onDuplicate={onDuplicate}
+          onDelete={onDelete}
+        />
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function LineItemActions({
+  itemName,
+  onDuplicate,
+  onDelete,
+}: {
+  itemName: string;
+  onDuplicate: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon-lg"
+            className="rounded-full text-muted-foreground"
+            aria-label={`Actions for ${itemName}`}
+          >
+            <EllipsisVertical className="size-5" />
+          </Button>
+        }
+      />
+      <DropdownMenuContent align="end" className="w-40">
+        <DropdownMenuItem>
+          <Pencil />
+          Edit
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={onDuplicate}>
+          <Copy />
+          Duplicate
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant="destructive" onClick={onDelete}>
+          <Trash2 />
+          Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function EstimateDragPreview({ row }: { row: SortableRowData }) {
+  return (
+    <div className="flex min-w-72 items-center gap-3 rounded-xl bg-card px-4 py-3 text-sm shadow-lg ring-1 ring-foreground/10">
+      <GripVertical className="size-5 shrink-0 text-muted-foreground" />
+      <span className="font-medium tabular-nums">{row.number}</span>
+      <span className="truncate font-medium">{row.label}</span>
+    </div>
+  );
+}
+
+function sectionSortableId(sectionId: string) {
+  return `section:${sectionId}`;
+}
+
+function itemSortableId(sectionId: string, itemId: string) {
+  return `item:${sectionId}:${itemId}`;
+}
+
+function calculateProfit(item: EstimateLineItem) {
+  const totalCost = item.quantity * item.unitCost;
+  const marginRate = item.marginPercent / 100;
+
+  if (marginRate <= 0 || marginRate >= 1) {
+    return 0;
+  }
+
+  return totalCost / (1 - marginRate) - totalCost;
+}

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/dashboard/job-details/job-details-content.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/dashboard/job-details/job-details-content.tsx
@@ -1,0 +1,49 @@
+import { EstimatesContent } from "./estimates-content";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../ui/tabs";
+import { jobEstimates } from "../../../data";
+import { useDashboardNavigation } from "../../navigation";
+
+const jobTabs = ["Estimates", "Plans", "Records", "Files"] as const;
+
+export function JobDetailsContent() {
+  const { pathname } = useDashboardNavigation();
+  const jobId = pathname.split("/")[2];
+
+  if (!jobId) {
+    return null;
+  }
+
+  const estimate = jobEstimates.find((item) => item.jobId === jobId);
+
+  return (
+    <section className="@container min-w-0 px-4 pt-4 pb-4 sm:px-6 sm:pt-7 sm:pb-6 lg:px-10 lg:pb-10">
+      <Tabs defaultValue="estimates" className="gap-0">
+        <TabsList
+          variant="line"
+          className="h-12 w-full justify-start gap-0 border-b p-0"
+        >
+          {jobTabs.map((tab) => (
+            <TabsTrigger
+              key={tab}
+              value={tab.toLowerCase()}
+              className="h-full flex-none px-4 text-base font-normal after:bottom-[-1px]! data-active:text-primary data-active:after:bg-primary"
+            >
+              {tab}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        <TabsContent value="estimates" className="mt-6">
+          <EstimatesContent key={jobId} sections={estimate?.sections ?? []} />
+        </TabsContent>
+        {jobTabs.slice(1).map((tab) => (
+          <TabsContent key={tab} value={tab.toLowerCase()} className="mt-6">
+            <div className="flex h-48 items-center justify-center rounded-xl border border-dashed text-muted-foreground">
+              No {tab.toLowerCase()} added yet
+            </div>
+          </TabsContent>
+        ))}
+      </Tabs>
+    </section>
+  );
+}

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/dashboard/jobs-content.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/dashboard/jobs-content.tsx
@@ -1,0 +1,306 @@
+import type { ComponentType, SVGProps } from "react";
+import { DashboardLink } from "../navigation";
+
+import {
+  AddIcon,
+  JobActiveIcon,
+  JobCustomerIcon,
+  JobDraftIcon,
+  JobLocationIcon,
+  JobTimeIcon,
+  SearchIcon,
+} from "../../assets/icons";
+import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "../ui/card";
+import { Input } from "../ui/input";
+import { Separator } from "../ui/separator";
+import { jobs, type Job, type JobStatus } from "../../data";
+import { cn } from "../../lib/utils";
+import { Archive, Check } from "lucide-react";
+
+type JobColumn = {
+  status: JobStatus;
+  label: string;
+  emptyMessage: string;
+  accentClassName: string;
+  countClassName: string;
+};
+
+const jobColumns: JobColumn[] = [
+  {
+    status: "pre-construction",
+    label: "Pre- Constructions",
+    emptyMessage: "No pre-construction jobs",
+    accentClassName: "text-[#3283ff] dark:text-[#66a3ff]",
+    countClassName:
+      "bg-[#3283ff]/10 text-[#3283ff] dark:bg-[#66a3ff]/15 dark:text-[#66a3ff]",
+  },
+  {
+    status: "active",
+    label: "Active",
+    emptyMessage: "No active jobs",
+    accentClassName: "text-[#ff5600] dark:text-[#ff7a38]",
+    countClassName:
+      "bg-[#ff5600]/10 text-[#ff5600] dark:bg-[#ff7a38]/15 dark:text-[#ff7a38]",
+  },
+  {
+    status: "complete",
+    label: "Complete",
+    emptyMessage: "No completed jobs",
+    accentClassName: "text-[#00c238] dark:text-[#35d968]",
+    countClassName:
+      "bg-[#00c238]/10 text-[#00c238] dark:bg-[#35d968]/15 dark:text-[#35d968]",
+  },
+  {
+    status: "closed",
+    label: "Closed",
+    emptyMessage: "No closed jobs",
+    accentClassName: "text-[#c57d00] dark:text-[#e4a83e]",
+    countClassName:
+      "bg-[#fef6e7] text-[#c57d00] dark:bg-[#e4a83e]/[0.12] dark:text-[#e4a83e]",
+  },
+];
+
+type JobBadgeDetails = {
+  label: string;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  className: string;
+};
+
+const jobBadgeDetails: Record<JobStatus, JobBadgeDetails> = {
+  "pre-construction": {
+    label: "Draft",
+    icon: JobDraftIcon,
+    className:
+      "bg-[#f2fff7] text-[#0e7b33] dark:bg-[#45c570]/[0.12] dark:text-[#45c570]",
+  },
+  active: {
+    label: "Active",
+    icon: JobActiveIcon,
+    className:
+      "bg-[#ff5600]/10 text-[#ff5600] dark:bg-[#ff7a38]/15 dark:text-[#ff7a38]",
+  },
+  complete: {
+    label: "Complete",
+    icon: Check,
+    className:
+      "bg-[#00c238]/10 text-[#00c238] dark:bg-[#35d968]/15 dark:text-[#35d968]",
+  },
+  closed: {
+    label: "Closed",
+    icon: Archive,
+    className:
+      "bg-[#fef6e7] text-[#c57d00] dark:bg-[#e4a83e]/[0.12] dark:text-[#e4a83e]",
+  },
+};
+
+export function JobsContent() {
+  return (
+    <section className="@container min-w-0 px-4 pt-4 pb-4 sm:px-6 sm:pt-7 sm:pb-6 lg:px-10 lg:pb-10">
+      <div className="flex flex-col gap-4 sm:gap-6 @4xl:flex-row @4xl:items-center @4xl:justify-between">
+        <div className="flex items-center justify-between gap-3 @4xl:shrink-0">
+          <h1 className="text-xl font-semibold tracking-tight sm:text-3xl">
+            Jobs
+          </h1>
+          <Button className="h-10 rounded-lg px-3 sm:hidden">
+            Add
+            <AddIcon className="size-4" />
+          </Button>
+        </div>
+        <div className="flex w-full flex-col gap-2 sm:flex-row @4xl:w-auto">
+          <div className="relative min-w-0 flex-1 sm:mr-auto sm:max-w-80 lg:max-w-96 @4xl:mr-0 @4xl:w-96 @4xl:flex-none">
+            <SearchIcon className="absolute top-1/2 left-3 size-5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              className="h-11 rounded-xl border-0 bg-muted pl-10 shadow-none md:text-base"
+              placeholder="Search job list"
+              aria-label="Search jobs"
+            />
+          </div>
+          <Button
+            size="lg"
+            className="hidden h-11 rounded-xl px-4 text-base sm:inline-flex"
+          >
+            Add Job
+            <AddIcon className="size-5" />
+          </Button>
+        </div>
+      </div>
+
+      <JobBoard />
+    </section>
+  );
+}
+
+function JobBoard() {
+  return (
+    <div className="mt-6 grid items-start gap-3 sm:mt-8 @2xl:grid-cols-2 @4xl:grid-cols-3 @5xl:grid-cols-4">
+      {jobColumns.map((column) => {
+        const columnJobs = jobs.filter((job) => job.status === column.status);
+
+        return (
+          <JobBoardColumn
+            key={column.status}
+            column={column}
+            jobs={columnJobs}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function JobBoardColumn({ column, jobs }: { column: JobColumn; jobs: Job[] }) {
+  return (
+    <section
+      className="rounded-2xl bg-sidebar p-1 pt-4"
+      aria-labelledby={`${column.status}-heading`}
+    >
+      <div className="mb-2 flex h-7 items-center justify-between pr-2">
+        <h2
+          id={`${column.status}-heading`}
+          className="flex items-center gap-2 font-medium"
+        >
+          <JobColumnMarker className={column.accentClassName} />
+          <span>{column.label}</span>
+        </h2>
+        <Badge
+          variant="secondary"
+          className={cn("h-6 rounded-lg font-normal", column.countClassName)}
+        >
+          {jobs.length}
+        </Badge>
+      </div>
+
+      <div className="space-y-2">
+        {jobs.length ? (
+          jobs.map((job) => <JobCard key={job.id} job={job} />)
+        ) : (
+          <div className="flex h-48 items-center justify-center rounded-xl border border-dashed bg-card px-3">
+            <p>{column.emptyMessage}</p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function JobColumnMarker({ className }: { className: string }) {
+  return (
+    <span
+      className={cn("flex h-7 w-1 shrink-0 flex-col gap-0.5", className)}
+      aria-hidden="true"
+    >
+      {[0, 1, 2].map((segment) => (
+        <span
+          key={segment}
+          className="h-2 w-full bg-current [clip-path:polygon(0_25%,100%_0,100%_75%,0_100%)]"
+        />
+      ))}
+    </span>
+  );
+}
+
+function JobCard({ job }: { job: Job }) {
+  return (
+    <DashboardLink
+      href={`/jobs/${job.id}/estimates`}
+      className="block rounded-xl outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+      aria-label={`Open ${job.title}`}
+    >
+      <Card
+        size="sm"
+        className="gap-0 py-0 shadow-none ring-0 transition-colors hover:bg-accent"
+      >
+        <CardHeader className="px-4 py-3">
+          <CardTitle>{job.title}</CardTitle>
+          <CardAction>
+            <JobStatusBadge status={job.status} />
+          </CardAction>
+        </CardHeader>
+        <Separator />
+
+        <CardContent className="space-y-3 px-4 py-4">
+          <div className="flex h-6 items-center justify-between gap-3">
+            <JobDetailLabel
+              icon={JobCustomerIcon}
+              iconClassName="text-[#15803d] dark:text-[#4ade80]"
+            >
+              Customer
+            </JobDetailLabel>
+            <div className="flex min-w-0 items-center gap-1 font-medium text-muted-foreground">
+              <Avatar className="size-5">
+                <AvatarImage src={job.customer.avatar} alt="" />
+                <AvatarFallback>{job.customer.name.slice(0, 2)}</AvatarFallback>
+              </Avatar>
+              <span className="truncate">{job.customer.name}</span>
+            </div>
+          </div>
+
+          <div className="flex items-start justify-between gap-3">
+            <JobDetailLabel
+              icon={JobLocationIcon}
+              iconClassName="text-[#1d4ed8] dark:text-[#60a5fa]"
+            >
+              Location
+            </JobDetailLabel>
+            <span className="max-w-48 text-right font-medium text-muted-foreground">
+              {job.location}
+            </span>
+          </div>
+
+          <div className="flex h-6 items-center justify-between gap-3">
+            <JobDetailLabel
+              icon={JobTimeIcon}
+              iconClassName="text-[#7c3aed] dark:text-[#a78bfa]"
+            >
+              Time
+            </JobDetailLabel>
+            <span className="font-medium text-muted-foreground">
+              {job.time}
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+    </DashboardLink>
+  );
+}
+
+function JobStatusBadge({ status }: { status: JobStatus }) {
+  const details = jobBadgeDetails[status];
+  const Icon = details.icon;
+
+  return (
+    <Badge
+      variant="secondary"
+      className={cn("h-6 rounded-full px-2.5 font-normal", details.className)}
+    >
+      <Icon />
+      {details.label}
+    </Badge>
+  );
+}
+
+function JobDetailLabel({
+  icon: Icon,
+  iconClassName,
+  children,
+}: {
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  iconClassName: string;
+  children: string;
+}) {
+  return (
+    <span className="flex shrink-0 items-center gap-2 text-muted-foreground">
+      <Icon className={cn("size-4", iconClassName)} />
+      {children}
+    </span>
+  );
+}

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/layout/app-sidebar.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/layout/app-sidebar.tsx
@@ -1,0 +1,117 @@
+import { Button } from "../ui/button";
+import {
+  type NavigationItem,
+  SidebarNavigationItem,
+} from "./sidebar-navigation-item";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarTrigger,
+  useSidebar,
+} from "../ui/sidebar";
+import {
+  CollapseIcon,
+  CustomersIcon,
+  JobsIcon,
+  LogoutIcon,
+  SettingsIcon,
+} from "../../assets/icons";
+import { Logo } from "../../assets/logo";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { DashboardLink } from "../navigation";
+
+type SidebarItem = NavigationItem & {
+  trailing?: "theme-toggle";
+};
+
+const primaryNavigationItems = [
+  { label: "Customers", href: "/", icon: CustomersIcon },
+  { label: "Jobs", href: "/jobs", icon: JobsIcon },
+] satisfies NavigationItem[];
+
+const utilityNavigationItems = [
+  { label: "Settings", icon: SettingsIcon, trailing: "theme-toggle" },
+  { label: "Logout", icon: LogoutIcon, variant: "destructive" },
+] satisfies SidebarItem[];
+
+function Brand() {
+  const { isMobile, setOpenMobile } = useSidebar();
+
+  return (
+    <div className="flex items-center justify-between">
+      <DashboardLink
+        href="/"
+        aria-label="JobTracker home"
+        className="flex max-w-48 min-w-0 items-center gap-2 overflow-hidden rounded-md transition-[max-width,opacity] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring group-data-[collapsible=icon]:max-w-0 group-data-[collapsible=icon]:opacity-0"
+        onClick={() => {
+          if (isMobile) {
+            setOpenMobile(false);
+          }
+        }}
+      >
+        <Logo className="size-5 shrink-0 text-primary" aria-hidden="true" />
+        <span className="whitespace-nowrap text-lg font-semibold tracking-tight">
+          JOB <span className="text-primary">TRACKER</span>
+        </span>
+      </DashboardLink>
+      <SidebarTrigger asChild>
+        <Button variant="ghost" size="icon-lg" aria-label="Toggle sidebar">
+          <CollapseIcon className="size-6 transition-transform duration-200 group-data-[state=collapsed]:rotate-180" />
+        </Button>
+      </SidebarTrigger>
+    </div>
+  );
+}
+
+function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const dark = resolvedTheme === "dark";
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon-lg"
+      className="hover:bg-secondary/80 group-data-[collapsible=icon]:hidden"
+      onClick={() => setTheme(dark ? "light" : "dark")}
+      aria-label={`Switch to ${dark ? "light" : "dark"} theme`}
+    >
+      <Sun className="size-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute size-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+    </Button>
+  );
+}
+
+export function AppSidebar() {
+  return (
+    <Sidebar collapsible="icon" className="border-none">
+      <SidebarHeader className="gap-6 p-3 transition-[padding] duration-200 group-data-[collapsible=icon]:p-2">
+        <Brand />
+        <SidebarMenu>
+          {primaryNavigationItems.map((item) => (
+            <SidebarNavigationItem key={item.label} item={item} />
+          ))}
+        </SidebarMenu>
+      </SidebarHeader>
+
+      <SidebarContent />
+
+      <SidebarFooter className="p-3 transition-[padding] duration-200 group-data-[collapsible=icon]:p-2">
+        <SidebarMenu>
+          {utilityNavigationItems.map((item) => (
+            <SidebarNavigationItem
+              key={item.label}
+              item={item}
+              trailing={
+                item.trailing === "theme-toggle" ? <ThemeToggle /> : undefined
+              }
+            />
+          ))}
+        </SidebarMenu>
+      </SidebarFooter>
+    </Sidebar>
+  );
+}

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/layout/dashboard-shell.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/layout/dashboard-shell.tsx
@@ -1,0 +1,34 @@
+import type { CSSProperties, ReactNode } from "react";
+
+import { AppSidebar } from "./app-sidebar";
+import { TopNavbar } from "./top-navbar";
+import { SidebarInset, SidebarProvider } from "../ui/sidebar";
+import { TooltipProvider } from "../ui/tooltip";
+
+type DashboardShellProps = {
+  children: ReactNode;
+};
+
+export function DashboardShell({ children }: DashboardShellProps) {
+  return (
+    <TooltipProvider>
+      <SidebarProvider
+        className="jobtracker-dashboard h-svh min-h-0 overflow-hidden"
+        style={
+          {
+            "--sidebar-width": "17rem",
+            "--sidebar-width-icon": "3.5rem",
+          } as CSSProperties
+        }
+      >
+        <AppSidebar />
+        <SidebarInset className="h-svh overflow-hidden">
+          <TopNavbar />
+          <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
+            {children}
+          </div>
+        </SidebarInset>
+      </SidebarProvider>
+    </TooltipProvider>
+  );
+}

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/layout/sidebar-navigation-item.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/layout/sidebar-navigation-item.tsx
@@ -1,0 +1,94 @@
+import type { ComponentType, ReactNode, SVGProps } from "react";
+
+import {
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from "../ui/sidebar";
+import { cn } from "../../lib/utils";
+import { DashboardLink, useDashboardNavigation } from "../navigation";
+
+export type NavigationItem = {
+  label: string;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  href?: string;
+  active?: boolean;
+  variant?: "default" | "destructive";
+};
+
+export const sidebarNavigationButtonClassName =
+  "h-10 gap-3 rounded-xl px-3 text-base font-medium tracking-tight [&_svg]:size-5";
+
+export const sidebarNavigationLabelClassName =
+  "max-w-40 whitespace-nowrap opacity-100 transition-[max-width,opacity] duration-200 group-data-[collapsible=icon]:max-w-0 group-data-[collapsible=icon]:opacity-0";
+
+type SidebarNavigationItemProps = {
+  item: NavigationItem;
+  trailing?: ReactNode;
+};
+
+export function SidebarNavigationItem({
+  item,
+  trailing,
+}: SidebarNavigationItemProps) {
+  const Icon = item.icon;
+  const { pathname } = useDashboardNavigation();
+  const { isMobile, setOpenMobile } = useSidebar();
+  const isActive =
+    item.active ??
+    (item.href === "/"
+      ? pathname === item.href
+      : Boolean(item.href && pathname.startsWith(item.href)));
+  const content = (
+    <>
+      <Icon />
+      <span className={sidebarNavigationLabelClassName}>{item.label}</span>
+    </>
+  );
+
+  if (item.href) {
+    return (
+      <SidebarMenuItem className={cn(trailing && "flex items-center gap-1")}>
+        <SidebarMenuButton
+          isActive={isActive}
+          variant={item.variant}
+          tooltip={item.label}
+          className={cn(
+            sidebarNavigationButtonClassName,
+            trailing && "min-w-0 flex-1",
+          )}
+          render={
+            <DashboardLink
+              href={item.href}
+              onClick={() => {
+                if (isMobile) {
+                  setOpenMobile(false);
+                }
+              }}
+            >
+              {content}
+            </DashboardLink>
+          }
+        />
+        {trailing}
+      </SidebarMenuItem>
+    );
+  }
+
+  return (
+    <SidebarMenuItem className={cn(trailing && "flex items-center gap-1")}>
+      <SidebarMenuButton
+        isActive={isActive}
+        variant={item.variant}
+        tooltip={item.label}
+        className={cn(
+          sidebarNavigationButtonClassName,
+          trailing && "min-w-0 flex-1",
+        )}
+      >
+        {content}
+      </SidebarMenuButton>
+      {trailing}
+    </SidebarMenuItem>
+  );
+}

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/layout/top-navbar.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/layout/top-navbar.tsx
@@ -37,7 +37,7 @@ export function TopNavbar() {
           <Button
             variant="ghost"
             size="icon-lg"
-            className="md:hidden"
+            className="lg:hidden"
             aria-label="Toggle sidebar"
           >
             <CollapseIcon className="size-6" />

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/layout/top-navbar.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/layout/top-navbar.tsx
@@ -1,0 +1,194 @@
+import {
+  CollapseIcon,
+  CustomersIcon,
+  JobsIcon,
+  MenuIcon,
+  NotificationIcon,
+} from "../../assets/icons";
+import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
+import { Button } from "../ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+import { SidebarTrigger } from "../ui/sidebar";
+import { currentUser, notifications } from "../../data";
+import { useIsMobile } from "../../hooks/use-mobile";
+import { CircleHelp, LogOut, Settings, UserRound } from "lucide-react";
+import { useDashboardNavigation } from "../navigation";
+
+export function TopNavbar() {
+  const isMobile = useIsMobile();
+  const { pathname } = useDashboardNavigation();
+  const currentPage = pathname.startsWith("/jobs")
+    ? { label: "Jobs", icon: JobsIcon }
+    : { label: "Customers", icon: CustomersIcon };
+  const PageIcon = currentPage.icon;
+
+  return (
+    <header className="flex h-16 shrink-0 items-center justify-between px-4 sm:px-6 lg:px-10">
+      <div className="flex min-w-0 items-center gap-3">
+        <SidebarTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-lg"
+            className="md:hidden"
+            aria-label="Toggle sidebar"
+          >
+            <CollapseIcon className="size-6" />
+          </Button>
+        </SidebarTrigger>
+        <PageIcon className="hidden size-5 shrink-0 md:block" />
+        <span className="truncate text-lg font-medium tracking-tight">
+          {currentPage.label}
+        </span>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        <NotificationsMenu
+          align={isMobile ? "center" : "end"}
+          collisionPadding={isMobile ? 16 : 5}
+        />
+        <ProfileMenu
+          align={isMobile ? "center" : "end"}
+          collisionPadding={isMobile ? 16 : 5}
+        />
+      </div>
+    </header>
+  );
+}
+
+type MenuPositioningProps = {
+  align: "center" | "end";
+  collisionPadding: number;
+};
+
+function NotificationsMenu({ align, collisionPadding }: MenuPositioningProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="secondary"
+            size="icon-lg"
+            className="relative rounded-full"
+            aria-label="Open notifications"
+          >
+            <NotificationIcon className="size-5" />
+            <span className="absolute top-2 right-2 size-2 rounded-full bg-red-500 ring-2 ring-sidebar" />
+          </Button>
+        }
+      />
+      <DropdownMenuContent
+        align={align}
+        sideOffset={8}
+        collisionPadding={collisionPadding}
+        className="w-72 rounded-xl p-2"
+      >
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="px-2 py-2 text-sm">
+            Notifications
+          </DropdownMenuLabel>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          {notifications.slice(0, 3).map((notification) => (
+            <DropdownMenuItem
+              key={notification.id}
+              className="block rounded-lg py-2.5"
+            >
+              <span className="flex min-w-0 items-center justify-between gap-3">
+                <span className="truncate font-medium">
+                  {notification.title}
+                </span>
+                <time className="shrink-0 text-xs text-muted-foreground">
+                  {notification.timestamp}
+                </time>
+              </span>
+              <span className="mt-0.5 block truncate text-sm text-muted-foreground">
+                {notification.description}
+              </span>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuGroup>
+        <div className="mt-1 border-t pt-1">
+          <Button variant="link" size="sm" className="w-full">
+            View all notifications
+          </Button>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function ProfileMenu({ align, collisionPadding }: MenuPositioningProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="secondary"
+            size="lg"
+            className="gap-1 rounded-full p-1 pr-1.5"
+            aria-label="Open profile menu"
+          >
+            <Avatar className="size-8">
+              <AvatarImage src={currentUser.avatar} alt={currentUser.name} />
+              <AvatarFallback>VP</AvatarFallback>
+            </Avatar>
+            <MenuIcon className="size-4" />
+          </Button>
+        }
+      />
+      <DropdownMenuContent
+        align={align}
+        sideOffset={8}
+        collisionPadding={collisionPadding}
+        className="w-72 rounded-xl p-2"
+      >
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="flex items-center gap-3 px-2 py-2 text-popover-foreground">
+            <Avatar className="size-9">
+              <AvatarImage src={currentUser.avatar} alt="VP" />
+              <AvatarFallback>VP</AvatarFallback>
+            </Avatar>
+            <span className="min-w-0">
+              <span className="block truncate font-medium">
+                {currentUser.name}
+              </span>
+              <span className="block truncate font-normal text-muted-foreground">
+                {currentUser.email}
+              </span>
+            </span>
+          </DropdownMenuLabel>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuItem className="rounded-lg">
+            <UserRound />
+            Profile
+          </DropdownMenuItem>
+          <DropdownMenuItem className="rounded-lg">
+            <Settings />
+            Settings
+          </DropdownMenuItem>
+          <DropdownMenuItem className="rounded-lg">
+            <CircleHelp />
+            Help and support
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownMenuGroup className="mt-1 border-t pt-1">
+          <DropdownMenuItem variant="destructive" className="rounded-lg">
+            <LogOut />
+            Log out
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/navigation.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/navigation.tsx
@@ -1,0 +1,76 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type AnchorHTMLAttributes,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+
+type DashboardNavigation = {
+  pathname: string;
+  navigate: (pathname: string) => void;
+};
+
+const DashboardNavigationContext = createContext<DashboardNavigation | null>(
+  null,
+);
+
+export function DashboardNavigationProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [pathname, setPathname] = useState("/");
+  const value = useMemo(
+    () => ({ pathname, navigate: setPathname }),
+    [pathname],
+  );
+
+  return (
+    <DashboardNavigationContext.Provider value={value}>
+      {children}
+    </DashboardNavigationContext.Provider>
+  );
+}
+
+export function useDashboardNavigation() {
+  const context = useContext(DashboardNavigationContext);
+
+  if (!context) {
+    throw new Error(
+      "useDashboardNavigation must be used within DashboardNavigationProvider",
+    );
+  }
+
+  return context;
+}
+
+export function DashboardLink({
+  href,
+  onClick,
+  ...props
+}: AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) {
+  const { navigate } = useDashboardNavigation();
+
+  function handleClick(event: MouseEvent<HTMLAnchorElement>) {
+    onClick?.(event);
+
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    navigate(href);
+  }
+
+  return <a href={href} onClick={handleClick} {...props} />;
+}

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/ui/avatar.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/ui/avatar.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import * as React from "react";
+import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar";
+
+import { cn } from "../../lib/utils";
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: AvatarPrimitive.Root.Props & {
+  size?: "default" | "sm" | "lg";
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border after:border-border after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarImage({ className, ...props }: AvatarPrimitive.Image.Props) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn(
+        "aspect-square size-full rounded-full object-cover",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: AvatarPrimitive.Fallback.Props) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground bg-blend-color ring-2 ring-background select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  AvatarBadge,
+};

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/ui/badge.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/ui/badge.tsx
@@ -1,0 +1,52 @@
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../../lib/utils";
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props,
+    ),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  });
+}
+
+export { Badge, badgeVariants };

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/ui/button.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/ui/button.tsx
@@ -1,0 +1,58 @@
+import { Button as ButtonPrimitive } from "@base-ui/react/button";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../../lib/utils";
+
+const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/80",
+        outline:
+          "border-border bg-background shadow-xs hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost:
+          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+        destructive:
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default:
+          "h-9 gap-1.5 px-2.5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),8px)] px-2 text-xs in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-8 gap-1 rounded-[min(var(--radius-md),10px)] px-2.5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5",
+        lg: "h-10 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        icon: "size-9",
+        "icon-xs":
+          "size-6 rounded-[min(var(--radius-md),8px)] in-data-[slot=button-group]:rounded-md [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm":
+          "size-8 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-md",
+        "icon-lg": "size-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  return (
+    <ButtonPrimitive
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/ui/card.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/ui/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react";
+
+import { cn } from "../../lib/utils";
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground shadow-xs ring-1 ring-foreground/10 [--card-spacing:--spacing(6)] has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(4)] *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "font-heading text-base leading-normal font-medium group-data-[size=sm]/card:text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-(--card-spacing)", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl px-(--card-spacing) [.border-t]:pt-(--card-spacing)",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+};

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/ui/dropdown-menu.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/ui/dropdown-menu.tsx
@@ -1,0 +1,272 @@
+import * as React from "react";
+import { Menu as MenuPrimitive } from "@base-ui/react/menu";
+
+import { cn } from "../../lib/utils";
+import { ChevronRightIcon, CheckIcon } from "lucide-react";
+
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
+  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
+}
+
+function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
+}
+
+function DropdownMenuContent({
+  align = "start",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  collisionPadding = 5,
+  className,
+  ...props
+}: MenuPrimitive.Popup.Props &
+  Pick<
+    MenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "collisionPadding" | "side" | "sideOffset"
+  >) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn(
+            "z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95",
+            className,
+          )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props) {
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: MenuPrimitive.GroupLabel.Props & {
+  inset?: boolean;
+}) {
+  return (
+    <MenuPrimitive.GroupLabel
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-xs font-medium text-muted-foreground data-inset:pl-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: MenuPrimitive.Item.Props & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
+  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: MenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean;
+}) {
+  return (
+    <MenuPrimitive.SubmenuTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-8 data-popup-open:bg-accent data-popup-open:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </MenuPrimitive.SubmenuTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  align = "start",
+  alignOffset = -3,
+  side = "right",
+  sideOffset = 0,
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuContent>) {
+  return (
+    <DropdownMenuContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "w-auto min-w-[96px] rounded-md bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+        className,
+      )}
+      align={align}
+      alignOffset={alignOffset}
+      side={side}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: MenuPrimitive.CheckboxItem.Props & {
+  inset?: boolean;
+}) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-8 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <MenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon />
+        </MenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+  return (
+    <MenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: MenuPrimitive.RadioItem.Props & {
+  inset?: boolean;
+}) {
+  return (
+    <MenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-8 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <MenuPrimitive.RadioItemIndicator>
+          <CheckIcon />
+        </MenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+};

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/ui/input.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { Input as InputPrimitive } from "@base-ui/react/input";
+
+import { cn } from "../../lib/utils";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/ui/select.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/ui/select.tsx
@@ -1,0 +1,199 @@
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
+
+import { cn } from "../../lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-md border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/ui/separator.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
+
+import { cn } from "../../lib/utils";
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/ui/sheet.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/ui/sheet.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import * as React from "react";
+import { Dialog as SheetPrimitive } from "@base-ui/react/dialog";
+
+import { cn } from "../../lib/utils";
+import { Button } from "./button";
+import { XIcon } from "lucide-react";
+
+function Sheet({ ...props }: SheetPrimitive.Root.Props) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({ ...props }: SheetPrimitive.Trigger.Props) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose({ ...props }: SheetPrimitive.Close.Props) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetPortal({ ...props }: SheetPrimitive.Portal.Props) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+}
+
+function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
+  return (
+    <SheetPrimitive.Backdrop
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/10 transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: SheetPrimitive.Popup.Props & {
+  side?: "top" | "right" | "bottom" | "left";
+  showCloseButton?: boolean;
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Popup
+        data-slot="sheet-content"
+        data-side={side}
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-ending-style:opacity-0 data-starting-style:opacity-0 data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=bottom]:data-ending-style:translate-y-[2.5rem] data-[side=bottom]:data-starting-style:translate-y-[2.5rem] data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=left]:data-ending-style:translate-x-[-2.5rem] data-[side=left]:data-starting-style:translate-x-[-2.5rem] data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=right]:data-ending-style:translate-x-[2.5rem] data-[side=right]:data-starting-style:translate-x-[2.5rem] data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=top]:data-ending-style:translate-y-[-2.5rem] data-[side=top]:data-starting-style:translate-y-[-2.5rem] data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close
+            data-slot="sheet-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-4 right-4"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Popup>
+    </SheetPortal>
+  );
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetTitle({ className, ...props }: SheetPrimitive.Title.Props) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("font-heading font-medium text-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: SheetPrimitive.Description.Props) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/ui/sidebar.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/ui/sidebar.tsx
@@ -205,7 +205,7 @@ function Sidebar({
 
   return (
     <div
-      className="group peer hidden text-sidebar-foreground md:block"
+      className="group peer hidden text-sidebar-foreground lg:block"
       data-state={state}
       data-collapsible={state === "collapsed" ? collapsible : ""}
       data-variant={variant}
@@ -228,7 +228,7 @@ function Sidebar({
         data-slot="sidebar-container"
         data-side={side}
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] lg:flex",
           // Adjust the padding for floating and inset variants.
           variant === "floating" || variant === "inset"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/ui/sidebar.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/ui/sidebar.tsx
@@ -1,0 +1,749 @@
+import * as React from "react";
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { useIsMobile } from "../../hooks/use-mobile";
+import { cn } from "../../lib/utils";
+import { Button } from "./button";
+import { Input } from "./input";
+import { Separator } from "./separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "./sheet";
+import { Skeleton } from "./skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "./tooltip";
+import { PanelLeftIcon } from "lucide-react";
+
+const SIDEBAR_COOKIE_NAME = "sidebar_state";
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+const SIDEBAR_WIDTH = "16rem";
+const SIDEBAR_WIDTH_MOBILE = "18rem";
+const SIDEBAR_WIDTH_ICON = "3rem";
+const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+
+type SidebarContextProps = {
+  state: "expanded" | "collapsed";
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  openMobile: boolean;
+  setOpenMobile: (open: boolean) => void;
+  isMobile: boolean;
+  toggleSidebar: () => void;
+};
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null);
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext);
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.");
+  }
+
+  return context;
+}
+
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: setOpenProp,
+  className,
+  style,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const isMobile = useIsMobile();
+  const [openMobile, setOpenMobile] = React.useState(false);
+
+  // This is the internal state of the sidebar.
+  // We use openProp and setOpenProp for control from outside the component.
+  const [_open, _setOpen] = React.useState(defaultOpen);
+  const open = openProp ?? _open;
+  const setOpen = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === "function" ? value(open) : value;
+      if (setOpenProp) {
+        setOpenProp(openState);
+      } else {
+        _setOpen(openState);
+      }
+
+      // This sets the cookie to keep the sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+    },
+    [setOpenProp, open],
+  );
+
+  // Helper to toggle the sidebar.
+  const toggleSidebar = React.useCallback(() => {
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
+  }, [isMobile, setOpen, setOpenMobile]);
+
+  // Adds a keyboard shortcut to toggle the sidebar.
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault();
+        toggleSidebar();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [toggleSidebar]);
+
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes.
+  const state = open ? "expanded" : "collapsed";
+
+  const contextValue = React.useMemo<SidebarContextProps>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+    }),
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar],
+  );
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <div
+        data-slot="sidebar-wrapper"
+        style={
+          {
+            "--sidebar-width": SIDEBAR_WIDTH,
+            "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+            ...style,
+          } as React.CSSProperties
+        }
+        className={cn(
+          "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </SidebarContext.Provider>
+  );
+}
+
+function Sidebar({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  children,
+  dir,
+  ...props
+}: React.ComponentProps<"div"> & {
+  side?: "left" | "right";
+  variant?: "sidebar" | "floating" | "inset";
+  collapsible?: "offcanvas" | "icon" | "none";
+}) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+
+  if (collapsible === "none") {
+    return (
+      <div
+        data-slot="sidebar"
+        className={cn(
+          "flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          dir={dir}
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <div
+      className="group peer hidden text-sidebar-foreground md:block"
+      data-state={state}
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-variant={variant}
+      data-side={side}
+      data-slot="sidebar"
+    >
+      {/* This is what handles the sidebar gap on desktop */}
+      <div
+        data-slot="sidebar-gap"
+        className={cn(
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "group-data-[collapsible=offcanvas]:w-0",
+          "group-data-[side=right]:rotate-180",
+          variant === "floating" || variant === "inset"
+            ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
+        )}
+      />
+      <div
+        data-slot="sidebar-container"
+        data-side={side}
+        className={cn(
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          // Adjust the padding for floating and inset variants.
+          variant === "floating" || variant === "inset"
+            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          className,
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar"
+          data-slot="sidebar-inner"
+          className="flex size-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1 group-data-[variant=floating]:ring-sidebar-border"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SidebarTrigger({
+  asChild = false,
+  className,
+  onClick,
+  children,
+  ...props
+}: React.ComponentProps<typeof Button> & {
+  asChild?: boolean;
+}) {
+  const { toggleSidebar } = useSidebar();
+
+  if (asChild && React.isValidElement(children)) {
+    const child = children as React.ReactElement<
+      React.ComponentProps<typeof Button>
+    >;
+    const handleClick: React.ComponentProps<typeof Button>["onClick"] = (
+      event,
+    ) => {
+      child.props.onClick?.(event);
+      onClick?.(event);
+      toggleSidebar();
+    };
+    const triggerProps = {
+      "data-sidebar": "trigger",
+      "data-slot": "sidebar-trigger",
+      className: cn(child.props.className, className),
+      onClick: handleClick,
+      ...props,
+    } as React.ComponentProps<typeof Button>;
+
+    return React.cloneElement(child, triggerProps);
+  }
+
+  return (
+    <Button
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="icon-sm"
+      className={cn(className)}
+      onClick={(event) => {
+        onClick?.(event);
+        toggleSidebar();
+      }}
+      {...props}
+    >
+      <PanelLeftIcon />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  );
+}
+
+function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
+        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        "relative flex min-w-0 flex-1 flex-col bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      data-sidebar="input"
+      className={cn("h-8 w-full bg-background shadow-none", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      data-sidebar="header"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      data-sidebar="footer"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      data-sidebar="separator"
+      className={cn("mx-2 w-auto bg-sidebar-border", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      data-sidebar="content"
+      className={cn(
+        "no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      data-sidebar="group"
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroupLabel({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"div"> & React.ComponentProps<"div">) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(
+          "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+          className,
+        ),
+      },
+      props,
+    ),
+    render,
+    state: {
+      slot: "sidebar-group-label",
+      sidebar: "group-label",
+    },
+  });
+}
+
+function SidebarGroupAction({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"button"> & React.ComponentProps<"button">) {
+  return useRender({
+    defaultTagName: "button",
+    props: mergeProps<"button">(
+      {
+        className: cn(
+          "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+          className,
+        ),
+      },
+      props,
+    ),
+    render,
+    state: {
+      slot: "sidebar-group-action",
+      sidebar: "group-action",
+    },
+  });
+}
+
+function SidebarGroupContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      data-sidebar="group-content"
+      className={cn("w-full text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      data-sidebar="menu"
+      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      data-sidebar="menu-item"
+      className={cn("group/menu-item relative", className)}
+      {...props}
+    />
+  );
+}
+
+const sidebarMenuButtonVariants = cva(
+  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding,background-color,color] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-10! group-data-[collapsible=icon]:p-2.5! hover:bg-secondary/80 hover:text-sidebar-foreground focus-visible:ring-2 active:bg-secondary/80 active:text-sidebar-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-secondary/80 data-open:hover:text-sidebar-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground data-active:hover:bg-sidebar-accent data-active:hover:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-secondary/80 hover:text-sidebar-foreground",
+        destructive:
+          "text-destructive hover:bg-destructive/10 hover:text-destructive active:bg-destructive/10 active:text-destructive",
+        outline:
+          "bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]",
+      },
+      size: {
+        default: "h-8 text-sm",
+        sm: "h-7 text-xs",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function SidebarMenuButton({
+  render,
+  isActive = false,
+  variant = "default",
+  size = "default",
+  tooltip,
+  className,
+  ...props
+}: useRender.ComponentProps<"button"> &
+  React.ComponentProps<"button"> & {
+    isActive?: boolean;
+    tooltip?: string | React.ComponentProps<typeof TooltipContent>;
+  } & VariantProps<typeof sidebarMenuButtonVariants>) {
+  const { isMobile, state } = useSidebar();
+  const comp = useRender({
+    defaultTagName: "button",
+    props: mergeProps<"button">(
+      {
+        className: cn(sidebarMenuButtonVariants({ variant, size }), className),
+      },
+      props,
+    ),
+    render: !tooltip ? render : <TooltipTrigger render={render} />,
+    state: {
+      slot: "sidebar-menu-button",
+      sidebar: "menu-button",
+      size,
+      active: isActive,
+    },
+  });
+
+  if (!tooltip) {
+    return comp;
+  }
+
+  if (typeof tooltip === "string") {
+    tooltip = {
+      children: tooltip,
+    };
+  }
+
+  return (
+    <Tooltip>
+      {comp}
+      <TooltipContent
+        side="right"
+        align="center"
+        hidden={state !== "collapsed" || isMobile}
+        {...tooltip}
+      />
+    </Tooltip>
+  );
+}
+
+function SidebarMenuAction({
+  className,
+  render,
+  showOnHover = false,
+  ...props
+}: useRender.ComponentProps<"button"> &
+  React.ComponentProps<"button"> & {
+    showOnHover?: boolean;
+  }) {
+  return useRender({
+    defaultTagName: "button",
+    props: mergeProps<"button">(
+      {
+        className: cn(
+          "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+          showOnHover &&
+            "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-active/menu-button:text-sidebar-accent-foreground aria-expanded:opacity-100 md:opacity-0",
+          className,
+        ),
+      },
+      props,
+    ),
+    render,
+    state: {
+      slot: "sidebar-menu-action",
+      sidebar: "menu-action",
+    },
+  });
+}
+
+function SidebarMenuBadge({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-menu-badge"
+      data-sidebar="menu-badge"
+      className={cn(
+        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 peer-data-active/menu-button:text-sidebar-accent-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSkeleton({
+  className,
+  showIcon = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showIcon?: boolean;
+}) {
+  // Random width between 50 to 90%.
+  const [width] = React.useState(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`;
+  });
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      data-sidebar="menu-skeleton"
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
+        />
+      )}
+      <Skeleton
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            "--skeleton-width": width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  );
+}
+
+function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      data-sidebar="menu-sub"
+      className={cn(
+        "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5 group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSubItem({
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      data-sidebar="menu-sub-item"
+      className={cn("group/menu-sub-item relative", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSubButton({
+  render,
+  size = "md",
+  isActive = false,
+  className,
+  ...props
+}: useRender.ComponentProps<"a"> &
+  React.ComponentProps<"a"> & {
+    size?: "sm" | "md";
+    isActive?: boolean;
+  }) {
+  return useRender({
+    defaultTagName: "a",
+    props: mergeProps<"a">(
+      {
+        className: cn(
+          "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+          className,
+        ),
+      },
+      props,
+    ),
+    render,
+    state: {
+      slot: "sidebar-menu-sub-button",
+      sidebar: "menu-sub-button",
+      size,
+      active: isActive,
+    },
+  });
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+};

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/ui/skeleton.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "../../lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/ui/table.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/ui/table.tsx
@@ -1,0 +1,123 @@
+import * as React from "react";
+
+import { cn } from "../../lib/utils";
+
+function Table({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<"table"> & {
+  containerClassName?: string;
+}) {
+  return (
+    <div
+      data-slot="table-container"
+      className={cn(
+        "relative w-full min-w-0 max-w-full overflow-x-auto",
+        containerClassName,
+      )}
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  );
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/ui/tabs.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/ui/tabs.tsx
@@ -1,0 +1,80 @@
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../../lib/utils";
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-horizontal:flex-col",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-9 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("flex-1 text-sm outline-none", className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };

--- a/src/data/contents/dashboards/jobtracker-dashboard/components/ui/tooltip.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/components/ui/tooltip.tsx
@@ -1,0 +1,64 @@
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
+
+import { cn } from "../../lib/utils";
+
+function TooltipProvider({
+  delay = 0,
+  ...props
+}: TooltipPrimitive.Provider.Props) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delay={delay}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  side = "top",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/data/contents/dashboards/jobtracker-dashboard/dashboard.css
+++ b/src/data/contents/dashboards/jobtracker-dashboard/dashboard.css
@@ -1,0 +1,61 @@
+.jobtracker-dashboard,
+[data-mobile="true"][data-sidebar="sidebar"] {
+  --background: #ffffff;
+  --foreground: #0a1b39;
+  --card: #ffffff;
+  --card-foreground: #0a1b39;
+  --popover: #ffffff;
+  --popover-foreground: #0a1b39;
+  --primary: #ea580b;
+  --primary-foreground: #ffffff;
+  --secondary: #f7f9fc;
+  --secondary-foreground: #0a1b39;
+  --muted: #f7f7f7;
+  --muted-foreground: #485066;
+  --accent: #f7f7f7;
+  --accent-foreground: #0a1b39;
+  --destructive: #ff0000;
+  --border: #e4e7ec;
+  --input: #f7f7f7;
+  --ring: #ea580b;
+  --sidebar: #f8f9fb;
+  --sidebar-foreground: #485066;
+  --sidebar-primary: #ea580b;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #ffffff;
+  --sidebar-accent-foreground: #ea580b;
+  --sidebar-border: #f8f9fb;
+  --sidebar-ring: #ea580b;
+  background-color: var(--background);
+  color: var(--foreground);
+}
+
+.dark .jobtracker-dashboard,
+.dark [data-mobile="true"][data-sidebar="sidebar"] {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
+}

--- a/src/data/contents/dashboards/jobtracker-dashboard/dashboardView.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/dashboardView.tsx
@@ -1,0 +1,30 @@
+import { CustomersContent } from "./components/dashboard/customers-content";
+import { JobDetailsContent } from "./components/dashboard/job-details/job-details-content";
+import { JobsContent } from "./components/dashboard/jobs-content";
+import { DashboardShell } from "./components/layout/dashboard-shell";
+import {
+  DashboardNavigationProvider,
+  useDashboardNavigation,
+} from "./components/navigation";
+
+function DashboardRoute() {
+  const { pathname } = useDashboardNavigation();
+
+  let content = <CustomersContent />;
+
+  if (pathname.startsWith("/jobs/")) {
+    content = <JobDetailsContent />;
+  } else if (pathname === "/jobs") {
+    content = <JobsContent />;
+  }
+
+  return <DashboardShell>{content}</DashboardShell>;
+}
+
+export default function DashboardView() {
+  return (
+    <DashboardNavigationProvider>
+      <DashboardRoute />
+    </DashboardNavigationProvider>
+  );
+}

--- a/src/data/contents/dashboards/jobtracker-dashboard/data/index.ts
+++ b/src/data/contents/dashboards/jobtracker-dashboard/data/index.ts
@@ -1,0 +1,201 @@
+export type Customer = {
+  name: string;
+  email: string;
+  phone: string;
+  avatar: string;
+};
+
+export type Notification = {
+  id: string;
+  title: string;
+  description: string;
+  timestamp: string;
+};
+
+export type JobStatus =
+  | "pre-construction"
+  | "active"
+  | "complete"
+  | "closed";
+
+export type Job = {
+  id: string;
+  title: string;
+  status: JobStatus;
+  customer: {
+    name: string;
+    avatar: string;
+  };
+  location: string;
+  time: string;
+};
+
+export type EstimateLineItem = {
+  id: string;
+  name: string;
+  csiCode?: string;
+  description?: string;
+  quantity: number;
+  unit: string;
+  unitCost: number;
+  marginPercent: number;
+};
+
+export type EstimateSection = {
+  id: string;
+  name: string;
+  items: EstimateLineItem[];
+};
+
+export type JobEstimate = {
+  jobId: string;
+  sections: EstimateSection[];
+};
+
+const diceBearAvatar = (seed: string) =>
+  `https://api.dicebear.com/10.x/avataaars/svg?seed=${encodeURIComponent(seed)}`;
+
+export const currentUser = {
+  name: "Vansh Patel",
+  email: "vanshpatel@gmail.com",
+  avatar: diceBearAvatar("Vansh Patel"),
+};
+
+export const notifications: Notification[] = [
+  {
+    id: "new-customer",
+    title: "New customer added",
+    description: "Sofia Martinez joined your customer list.",
+    timestamp: "2m ago",
+  },
+  {
+    id: "job-status",
+    title: "Job status updated",
+    description: "Product Designer moved to the next stage.",
+    timestamp: "1h ago",
+  },
+];
+
+export const customers: Customer[] = [
+  {
+    name: "Vansh Patel",
+    email: "vanshpatel@gmail.com",
+    phone: "+1 970-2403456",
+    avatar: diceBearAvatar("Vansh Patel"),
+  },
+  {
+    name: "Sofia Martinez",
+    email: "sofiamartinez@example.com",
+    phone: "+1 202-5550189",
+    avatar: diceBearAvatar("Sofia Martinez"),
+  },
+  {
+    name: "Zara Khan",
+    email: "zarak@example.com",
+    phone: "+1 305-5550191",
+    avatar: diceBearAvatar("Zara Khan"),
+  },
+  {
+    name: "Ethan Patel",
+    email: "ethanp@example.com",
+    phone: "+1 503-5550192",
+    avatar: diceBearAvatar("Ethan Patel"),
+  },
+  {
+    name: "Liam Johnson",
+    email: "liamj@example.com",
+    phone: "+1 415-5550190",
+    avatar: diceBearAvatar("Liam Johnson"),
+  },
+];
+
+export const jobs: Job[] = [
+  {
+    id: "kitchen-remodel-1",
+    title: "Kitchen Remodel",
+    status: "pre-construction",
+    customer: {
+      name: "Vansh P.",
+      avatar: diceBearAvatar("Vansh Patel"),
+    },
+    location: "No 14, Bro, Allan avenue, Lekki county",
+    time: "Just Now",
+  },
+  {
+    id: "kitchen-remodel-2",
+    title: "Kitchen Remodel",
+    status: "pre-construction",
+    customer: {
+      name: "Vansh P.",
+      avatar: diceBearAvatar("Vansh Patel"),
+    },
+    location: "No 14, Bro, Allan avenue, Lekki county",
+    time: "Just Now",
+  },
+  {
+    id: "kitchen-remodel-3",
+    title: "Kitchen Remodel",
+    status: "pre-construction",
+    customer: {
+      name: "Vansh P.",
+      avatar: diceBearAvatar("Vansh Patel"),
+    },
+    location: "No 14, Bro, Allan avenue, Lekki county",
+    time: "Just Now",
+  },
+  {
+    id: "kitchen-remodel-4",
+    title: "Kitchen Remodel",
+    status: "active",
+    customer: {
+      name: "Vansh P.",
+      avatar: diceBearAvatar("Vansh Patel"),
+    },
+    location: "No 14, Bro, Allan avenue, Lekki county",
+    time: "Just Now",
+  },
+];
+
+export const jobEstimates: JobEstimate[] = [
+  {
+    jobId: "kitchen-remodel-1",
+    sections: [
+      {
+        id: "base",
+        name: "Base",
+        items: [
+          {
+            id: "tiles",
+            name: "Tiles",
+            quantity: 1,
+            unit: "LS",
+            unitCost: 10,
+            marginPercent: 20,
+          },
+          {
+            id: "cement",
+            name: "Cement",
+            quantity: 1,
+            unit: "LS",
+            unitCost: 7,
+            marginPercent: 10,
+          },
+        ],
+      },
+      {
+        id: "furniture",
+        name: "Furniture",
+        items: [
+          {
+            id: "wood",
+            name: "Wood",
+            quantity: 1,
+            unit: "LS",
+            unitCost: 10,
+            marginPercent: 20,
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/src/data/contents/dashboards/jobtracker-dashboard/demo.tsx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/demo.tsx
@@ -1,0 +1,7 @@
+import "./dashboard.css";
+
+import DashboardView from "./dashboardView";
+
+export default function JobtrackerDashboardDemo() {
+  return <DashboardView />;
+}

--- a/src/data/contents/dashboards/jobtracker-dashboard/hooks/use-mobile.ts
+++ b/src/data/contents/dashboards/jobtracker-dashboard/hooks/use-mobile.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-const MOBILE_BREAKPOINT = 768;
+const MOBILE_BREAKPOINT = 1024;
 
 export function useIsMobile() {
   const query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;

--- a/src/data/contents/dashboards/jobtracker-dashboard/hooks/use-mobile.ts
+++ b/src/data/contents/dashboards/jobtracker-dashboard/hooks/use-mobile.ts
@@ -1,0 +1,17 @@
+import * as React from "react";
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile() {
+  const query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
+
+  return React.useSyncExternalStore(
+    (onStoreChange) => {
+      const mediaQuery = window.matchMedia(query);
+      mediaQuery.addEventListener("change", onStoreChange);
+      return () => mediaQuery.removeEventListener("change", onStoreChange);
+    },
+    () => window.matchMedia(query).matches,
+    () => false,
+  );
+}

--- a/src/data/contents/dashboards/jobtracker-dashboard/jobtracker-dashboard.mdx
+++ b/src/data/contents/dashboards/jobtracker-dashboard/jobtracker-dashboard.mdx
@@ -1,0 +1,26 @@
+---
+title: Jobtracker Dashboard
+slug: jobtracker-dashboard
+category: dashboard
+image: 'https://assets.watermelon.sh/components/jobtracker-dashboard-thumbnail.png'
+description: >-
+  A responsive job management workspace with customer records, job pipelines,
+  estimates, drag-and-drop line items, and light and dark themes.
+featured: false
+dependencies:
+  - '@base-ui/react'
+  - '@dnd-kit/core'
+  - '@dnd-kit/modifiers'
+  - '@dnd-kit/sortable'
+  - '@dnd-kit/utilities'
+  - class-variance-authority
+  - clsx
+  - lucide-react
+  - next-themes
+  - tailwind-merge
+install:
+  - >-
+    npx shadcn@latest add
+    https://registry.watermelon.sh/r/jobtracker-dashboard.json
+componentNumber: 18
+---

--- a/src/data/contents/dashboards/jobtracker-dashboard/lib/utils.ts
+++ b/src/data/contents/dashboards/jobtracker-dashboard/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Description

Adds the Scoutout dashboard to the platform as **Jobtracker Dashboard**, including customers, jobs, estimates, responsive navigation, isolated preview theming, registry metadata, and thumbnail.

Also fixes tablet sidebar behavior by aligning the mobile hook and responsive sidebar breakpoint at `1024px`.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Tested locally with dev server
- [x] Checked against ESLint and TypeScript errors
- [x] Production build completed successfully

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Added new dashboard to the registry and checked indexing numbers
- [x] Added dashboard thumbnail and metadata