### PR TITLE
Fix MCP Worker handler crash

### DIFF
--- a/mcp/worker.test.ts
+++ b/mcp/worker.test.ts
@@ -31,6 +31,33 @@ describe('mcp worker', () => {
     expect(body.build.generatedAt).toBeTruthy();
   });
 
+  it('accepts an MCP initialize handshake without a Worker crash', async () => {
+    const response = await mcpWorker.fetch(
+      new Request('https://mcp.watermelon.sh/mcp', {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-03-26',
+            capabilities: {},
+            clientInfo: { name: 'watermelon-test-client', version: '1.0.0' },
+          },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('text/event-stream');
+    const body = await response.text();
+    expect(body).toContain('"name":"watermelon-mcp"');
+  });
+
   it('returns a structured not-found response for unknown routes', async () => {
     const response = await mcpWorker.fetch(
       new Request('https://mcp.watermelon.sh/nope'),

--- a/mcp/worker.ts
+++ b/mcp/worker.ts
@@ -3,9 +3,9 @@ import { catalog } from './catalog.generated';
 import { createCatalogServer } from './catalog';
 import { opsMetadata } from '../src/data/ops.generated';
 
-const mcpHandler = createMcpHandler(() => createCatalogServer(catalog), {
-  legacy: 'reject',
-});
+// Keep the default stateless legacy path so established MCP clients can still
+// negotiate the 2025 protocol revision while newer clients use the current one.
+const mcpHandler = createMcpHandler(() => createCatalogServer(catalog));
 
 const corsHeaders = {
   'Access-Control-Allow-Headers':
@@ -120,7 +120,7 @@ export default {
     }
 
     if (url.pathname === '/mcp') {
-      return mcpHandler(request);
+      return mcpHandler.fetch(request);
     }
 
     return json(


### PR DESCRIPTION
## Summary
- call the MCP SDK handler through its supported fetch interface
- retain stateless compatibility for established 2025 MCP clients
- add an initialize handshake regression test

## Verification
- bun test mcp/worker.test.ts
- bun run build