### PR TITLE
Fix knob slider blur after pointer release

### DIFF
--- a/src/data/contents/animated-components/knob-slider/base.tsx
+++ b/src/data/contents/animated-components/knob-slider/base.tsx
@@ -160,7 +160,10 @@ export const KnobSlider: React.FC<KnobSliderProps> = ({
   useEffect(() => {
     const move = (e: MouseEvent) =>
       dragging && updateFromPointer(e.clientX, e.clientY);
-    const up = () => setDragging(false);
+    const up = () => {
+      setDragging(false);
+      setBlur(0);
+    };
 
     if (dragging) {
       window.addEventListener('mousemove', move);

--- a/src/data/contents/animated-components/knob-slider/original.tsx
+++ b/src/data/contents/animated-components/knob-slider/original.tsx
@@ -173,7 +173,10 @@ export const KnobSlider: React.FC<KnobSliderProps> = ({
     useEffect(() => {
         const move = (e: MouseEvent) =>
             dragging && updateFromPointer(e.clientX, e.clientY);
-        const up = () => setDragging(false);
+        const up = () => {
+            setDragging(false);
+            setBlur(0);
+        };
 
         if (dragging) {
             window.addEventListener("mousemove", move);


### PR DESCRIPTION
## Description

Clear the Knob Slider blur state when the pointer is released so the selected value remains readable after interaction.

The fix is applied to both the Original and Custom Theme implementations. No generated files or unrelated component code are included.

Fixes #183

## Before and After

### Before

The selected value remains blurred after the pointer is released.

![Knob Slider value remaining blurred after interaction](https://raw.githubusercontent.com/jashkarangiya/watermelon-platform/9f697b515090d1196c56a769d37f1050a9ffa54a/issue-assets/knob-slider-before.jpg)

### After

The selected value becomes readable when the pointer is released.

![Knob Slider value clear after pointer release](https://raw.githubusercontent.com/jashkarangiya/watermelon-platform/9f697b515090d1196c56a769d37f1050a9ffa54a/issue-assets/knob-slider-after.jpg)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Reproduced the issue locally and confirmed the value remained at `blur(10px)` after interaction.
- Verified both pointer interactions settle at `blur(0px)` after the fix.
- Confirmed there are no browser console errors.
- [x] Tested locally with dev server
- [x] Checked against Lint & TypeScript errors
- [x] Ran `bun run lint`
- [x] Ran `bun run build`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Documentation changes are not required
- [x] Registry changes are not required
