### PR TITLE
Add MCP analytics and shadcn registry delivery

### DIFF
--- a/.github/workflows/publish-watermelon-cli.yml
+++ b/.github/workflows/publish-watermelon-cli.yml
@@ -1,0 +1,28 @@
+name: Publish Watermelon UI CLI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify package contents
+        run: npm pack --dry-run
+        working-directory: packages/cli
+
+      - name: Publish public package
+        run: npm publish --access public
+        working-directory: packages/cli
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,8 @@ dist-ssr
 .cursorignore
 .wrangler
 
+# Generated shadcn registry payloads are rebuilt during every platform deploy.
+/public/r/
+/public/registry.json
+
 /skills/

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Useful commands:
 - `bun run mcp`: start the local Watermelon MCP server over stdio
 - `bun run mcp:dev`: run the hosted MCP Worker locally
 - `bun run mcp:deploy`: deploy the hosted MCP Worker to Cloudflare
+- `bun run generate:shadcn-registry`: generate installable shadcn registry JSON
 
 Public machine-readable endpoints:
 
@@ -67,6 +68,21 @@ Most public content is file-based and lives in `src/data/contents`.
 - `templates/`: template entries and demos
 
 Routes are wired in `src/components/layout/app-routes.tsx`, and the sitemap is generated from the same content model in `scripts/generate-sitemap.ts`.
+
+## Installable Components
+
+Watermelon components are distributed as copy-paste shadcn registry items, so
+the resulting code lives in the consuming project and remains fully editable.
+
+```bash
+npx shadcn@latest add https://registry.watermelon.sh/r/card-split-accordian.json
+```
+
+The registry is generated from the maintained animated component source during
+every platform build. A release-ready CLI lives in `packages/cli`; its public
+npm package name is `@watermelon-ui/cli`. Publishing requires an npm
+organization and the `NPM_TOKEN` GitHub repository secret, then runs through
+the manual `Publish Watermelon UI CLI` workflow.
 
 ## Contributing
 
@@ -93,6 +109,10 @@ Watermelon includes a few machine-readable surfaces to help agents and tooling u
 - `worker/site.ts`
 
 The hosted MCP endpoint is intended to live at `https://mcp.watermelon.sh/mcp`.
+
+The hosted Worker records aggregate `initialize` and `tools/call` event counts
+in Cloudflare Analytics Engine. It does not retain IP addresses, session IDs,
+prompts, tool arguments, or client-provided versions.
 
 ## Repository Health
 

--- a/mcp/worker.test.ts
+++ b/mcp/worker.test.ts
@@ -58,6 +58,70 @@ describe('mcp worker', () => {
     expect(body).toContain('"name":"watermelon-mcp"');
   });
 
+  it('records aggregate MCP telemetry without storing client identifiers', async () => {
+    const points: Array<{ blobs: string[]; doubles: number[]; indexes: string[] }> = [];
+    const response = await mcpWorker.fetch(
+      new Request('https://mcp.watermelon.sh/mcp', {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          'Content-Type': 'application/json',
+          'Content-Length': '160',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-03-26',
+            capabilities: {},
+            clientInfo: { name: 'ChatGPT Desktop', version: '1.0.0' },
+          },
+        }),
+      }),
+      { MCP_ANALYTICS: { writeDataPoint: (point) => points.push(point) } },
+    );
+
+    expect(response.status).toBe(200);
+    expect(points).toEqual([
+      {
+        blobs: ['initialize', 'chatgpt', 'handshake'],
+        doubles: [1],
+        indexes: ['initialize'],
+      },
+    ]);
+  });
+
+  it('records only allowlisted tool names in aggregate telemetry', async () => {
+    const points: Array<{ blobs: string[]; doubles: number[]; indexes: string[] }> = [];
+    const response = await mcpWorker.fetch(
+      new Request('https://mcp.watermelon.sh/mcp', {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          'Content-Type': 'application/json',
+          'Content-Length': '100',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name: 'list_catalog_entries', arguments: {} },
+        }),
+      }),
+      { MCP_ANALYTICS: { writeDataPoint: (point) => points.push(point) } },
+    );
+
+    expect(response.status).toBeGreaterThanOrEqual(200);
+    expect(points).toEqual([
+      {
+        blobs: ['tool_call', 'unknown', 'list_catalog_entries'],
+        doubles: [1],
+        indexes: ['tool_call'],
+      },
+    ]);
+  });
+
   it('returns a structured not-found response for unknown routes', async () => {
     const response = await mcpWorker.fetch(
       new Request('https://mcp.watermelon.sh/nope'),

--- a/mcp/worker.ts
+++ b/mcp/worker.ts
@@ -6,6 +6,29 @@ import { opsMetadata } from '../src/data/ops.generated';
 // Keep the default stateless legacy path so established MCP clients can still
 // negotiate the 2025 protocol revision while newer clients use the current one.
 const mcpHandler = createMcpHandler(() => createCatalogServer(catalog));
+const knownToolNames = new Set([
+  'catalog_summary',
+  'list_catalog_entries',
+  'get_catalog_entry',
+]);
+
+type AnalyticsDataset = {
+  writeDataPoint(dataPoint: {
+    blobs: string[];
+    doubles: number[];
+    indexes: string[];
+  }): void;
+};
+
+type Env = {
+  MCP_ANALYTICS?: AnalyticsDataset;
+};
+
+type McpTelemetryEvent = {
+  event: 'initialize' | 'tool_call';
+  clientType: string;
+  detail: string;
+};
 
 const corsHeaders = {
   'Access-Control-Allow-Headers':
@@ -62,8 +85,69 @@ function getRuntimeMetadata() {
   };
 }
 
+function normalizeClientType(clientName: unknown) {
+  const name = typeof clientName === 'string' ? clientName.toLowerCase() : '';
+
+  if (name.includes('chatgpt')) return 'chatgpt';
+  if (name.includes('claude')) return 'claude';
+  if (name.includes('cursor')) return 'cursor';
+  if (name.includes('codex')) return 'codex';
+  if (name) return 'other';
+
+  return 'unknown';
+}
+
+async function readMcpTelemetry(request: Request): Promise<McpTelemetryEvent | null> {
+  if (request.method !== 'POST') return null;
+
+  const contentLength = Number(request.headers.get('content-length') ?? 0);
+  if (!Number.isFinite(contentLength) || contentLength <= 0 || contentLength > 65_536) {
+    return null;
+  }
+
+  try {
+    const payload = (await request.clone().json()) as {
+      method?: unknown;
+      params?: { name?: unknown; clientInfo?: { name?: unknown } };
+    };
+
+    if (payload.method === 'initialize') {
+      return {
+        event: 'initialize',
+        clientType: normalizeClientType(payload.params?.clientInfo?.name),
+        detail: 'handshake',
+      };
+    }
+
+    if (payload.method === 'tools/call' && typeof payload.params?.name === 'string') {
+      return {
+        event: 'tool_call',
+        clientType: 'unknown',
+        detail: knownToolNames.has(payload.params.name)
+          ? payload.params.name
+          : 'other',
+      };
+    }
+  } catch {
+    // Invalid MCP payloads are handled by the MCP transport, not analytics.
+  }
+
+  return null;
+}
+
+function recordMcpTelemetry(dataset: AnalyticsDataset | undefined, event: McpTelemetryEvent | null) {
+  if (!dataset || !event) return;
+
+  // No IP, session ID, prompt, arguments, or client-provided version is retained.
+  dataset.writeDataPoint({
+    blobs: [event.event, event.clientType, event.detail],
+    doubles: [1],
+    indexes: [event.event],
+  });
+}
+
 export default {
-  async fetch(request: Request): Promise<Response> {
+  async fetch(request: Request, env: Env = {}): Promise<Response> {
     const url = new URL(request.url);
 
     if (request.method === 'OPTIONS') {
@@ -78,6 +162,10 @@ export default {
         transport: 'streamable-http',
         docs: 'https://ui.watermelon.sh/developers/mcp',
         status: 'https://ui.watermelon.sh/developers/status',
+        analytics: {
+          enabled: Boolean(env.MCP_ANALYTICS),
+          privacy: 'Aggregate event counts only. No IP addresses, session IDs, prompts, or tool arguments are stored.',
+        },
         build: getRuntimeMetadata(),
         ...getCatalogStats(),
       });
@@ -120,6 +208,7 @@ export default {
     }
 
     if (url.pathname === '/mcp') {
+      recordMcpTelemetry(env.MCP_ANALYTICS, await readMcpTelemetry(request));
       return mcpHandler.fetch(request);
     }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "bun run sitemap && bun run generate:mcp-catalog && bun run generate:ops && tsc -b && vite build && cp dist/index.html dist/404.html",
+    "build": "bun run sitemap && bun run generate:mcp-catalog && bun run generate:ops && bun run generate:shadcn-registry && tsc -b && vite build && cp dist/index.html dist/404.html",
     "lint": "eslint .",
     "preview": "vite preview",
     "sitemap": "bun run scripts/generate-sitemap.ts",
@@ -13,6 +13,7 @@
     "generate:mcp-catalog": "bun run scripts/generate-mcp-catalog.ts",
     "generate:ops": "bun run scripts/generate-ops-manifest.ts",
     "generate:star-history": "bun run scripts/generate-star-history.ts",
+    "generate:shadcn-registry": "bun run scripts/generate-shadcn-registry.ts",
     "prepare": "husky",
     "mcp": "bun run generate:mcp-catalog && bun run mcp/server.ts",
     "mcp:dev": "bun run generate:mcp-catalog && bunx wrangler dev --config wrangler.mcp.toml",

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 WatermelonCorp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,15 @@
+# Watermelon UI CLI
+
+Install copy-paste Watermelon UI components through the shadcn CLI.
+
+```bash
+npx @watermelon-ui/cli add card-split-accordian
+```
+
+For the theme-token base variant:
+
+```bash
+npx @watermelon-ui/cli add card-split-accordian --base
+```
+
+The CLI runs `shadcn add` against the public Watermelon registry, so installed code belongs to your project and can be edited freely.

--- a/packages/cli/bin/watermelon-ui.mjs
+++ b/packages/cli/bin/watermelon-ui.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+
+const REGISTRY_URL = 'https://registry.watermelon.sh/r';
+const slugPattern = /^[a-z0-9]+(?:[a-z0-9-]*[a-z0-9])?$/;
+
+function usage() {
+  console.log(`Watermelon UI CLI
+
+Usage:
+  npx @watermelon-ui/cli add <component>
+  npx @watermelon-ui/cli add <component> --base
+
+Examples:
+  npx @watermelon-ui/cli add card-split-accordian
+  npx @watermelon-ui/cli add card-split-accordian --base`);
+}
+
+const [command, component, ...flags] = process.argv.slice(2);
+
+if (!command || command === '--help' || command === '-h') {
+  usage();
+  process.exit(0);
+}
+
+if (command !== 'add' || !component || !slugPattern.test(component)) {
+  console.error('Use `watermelon-ui add <component>` with a lowercase component slug.');
+  process.exit(1);
+}
+
+const suffix = flags.includes('--base') ? '-base' : '';
+const registryItem = `${REGISTRY_URL}/${component}${suffix}.json`;
+const child = spawn('npx', ['shadcn@latest', 'add', registryItem], {
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+});
+
+child.on('exit', (code) => process.exit(code ?? 1));

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@watermelon-ui/cli",
+  "version": "0.1.0",
+  "description": "Install Watermelon UI components with the shadcn CLI.",
+  "type": "module",
+  "bin": {
+    "watermelon-ui": "./bin/watermelon-ui.mjs"
+  },
+  "files": [
+    "bin",
+    "README.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "watermelon",
+    "watermelon-ui",
+    "shadcn",
+    "react",
+    "tailwind"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/WatermelonCorp/watermelon-platform.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/WatermelonCorp/watermelon-platform/issues"
+  },
+  "homepage": "https://ui.watermelon.sh/installation",
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/scripts/generate-shadcn-registry.test.ts
+++ b/scripts/generate-shadcn-registry.test.ts
@@ -1,0 +1,40 @@
+import { afterAll, describe, expect, it } from 'bun:test';
+import { mkdir, readFile, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { generateShadcnRegistry } from './generate-shadcn-registry';
+
+const testDirectory = path.join(import.meta.dir, '.registry-test-output');
+
+afterAll(async () => {
+  await rm(testDirectory, { recursive: true, force: true });
+});
+
+describe('generateShadcnRegistry', () => {
+  it('builds installable original and base variants from maintained components', async () => {
+    await mkdir(testDirectory, { recursive: true });
+    const { items, manifest } = await generateShadcnRegistry(
+      testDirectory,
+      path.join(testDirectory, 'registry.json'),
+    );
+
+    expect(items.length).toBeGreaterThan(200);
+    expect(manifest.name).toBe('watermelon');
+
+    const item = JSON.parse(
+      await readFile(
+        path.join(testDirectory, 'card-split-accordian.json'),
+        'utf8',
+      ),
+    );
+
+    expect(item.$schema).toBe('https://ui.shadcn.com/schema/registry-item.json');
+    expect(item.type).toBe('registry:component');
+    expect(item.dependencies).toEqual(
+      expect.arrayContaining(['lucide-react', 'motion', 'react-icons', 'react-use-measure']),
+    );
+    expect(item.files[0].path).toBe(
+      'components/watermelon/card-split-accordian.tsx',
+    );
+    expect(item.files[0].content).toContain('export const AccordionApp');
+  });
+});

--- a/scripts/generate-shadcn-registry.ts
+++ b/scripts/generate-shadcn-registry.ts
@@ -1,0 +1,163 @@
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import matter from 'gray-matter';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const REGISTRY_CONTENT_DIRECTORY = path.join(
+  ROOT,
+  'src/data/contents/registry',
+);
+const COMPONENT_DIRECTORY = path.join(
+  ROOT,
+  'src/data/contents/animated-components',
+);
+const OUTPUT_DIRECTORY = path.join(ROOT, 'public/r');
+const REGISTRY_MANIFEST_PATH = path.join(ROOT, 'public/registry.json');
+
+type RegistryItem = {
+  $schema: string;
+  name: string;
+  type: 'registry:component';
+  title: string;
+  description: string;
+  dependencies: string[];
+  registryDependencies?: string[];
+  files: Array<{
+    path: string;
+    type: 'registry:component';
+    content: string;
+  }>;
+};
+
+function packageName(importSource: string) {
+  if (importSource.startsWith('@')) {
+    return importSource.split('/').slice(0, 2).join('/');
+  }
+
+  return importSource.split('/')[0];
+}
+
+function dependenciesFromSource(source: string) {
+  const imports = source.matchAll(/from\s+['"]([^'"]+)['"]/g);
+  const dependencies = new Set<string>();
+
+  for (const match of imports) {
+    const importSource = match[1];
+
+    if (
+      importSource.startsWith('.') ||
+      importSource.startsWith('@/') ||
+      importSource === 'react' ||
+      importSource === 'react-dom'
+    ) {
+      continue;
+    }
+
+    dependencies.add(packageName(importSource));
+  }
+
+  return [...dependencies].sort();
+}
+
+async function readComponentVariant(slug: string, variant: 'original' | 'base') {
+  return readFile(
+    path.join(COMPONENT_DIRECTORY, slug, `${variant}.tsx`),
+    'utf8',
+  );
+}
+
+export async function buildRegistryItems() {
+  const files = await readdir(REGISTRY_CONTENT_DIRECTORY);
+  const items: RegistryItem[] = [];
+
+  for (const filename of files.filter((file) => file.endsWith('.mdx')).sort()) {
+    const metadata = matter(
+      await readFile(path.join(REGISTRY_CONTENT_DIRECTORY, filename), 'utf8'),
+    ).data as { title?: string; slug?: string; description?: string };
+    const slug = metadata.slug;
+
+    if (!slug) continue;
+
+    try {
+      const original = await readComponentVariant(slug, 'original');
+      const base = await readComponentVariant(slug, 'base');
+      const dependencies = dependenciesFromSource(`${original}\n${base}`);
+      const registryDependencies = original.includes("@/lib/utils") || base.includes("@/lib/utils")
+        ? ['utils']
+        : undefined;
+
+      items.push({
+        $schema: 'https://ui.shadcn.com/schema/registry-item.json',
+        name: slug,
+        type: 'registry:component',
+        title: metadata.title ?? slug,
+        description: metadata.description ?? `Watermelon UI component: ${slug}.`,
+        dependencies,
+        ...(registryDependencies ? { registryDependencies } : {}),
+        files: [
+          {
+            path: `components/watermelon/${slug}.tsx`,
+            type: 'registry:component',
+            content: original,
+          },
+        ],
+      });
+
+      items.push({
+        $schema: 'https://ui.shadcn.com/schema/registry-item.json',
+        name: `${slug}-base`,
+        type: 'registry:component',
+        title: `${metadata.title ?? slug} (base)`,
+        description: `Theme-ready base variant of ${metadata.description ?? slug}.`,
+        dependencies,
+        ...(registryDependencies ? { registryDependencies } : {}),
+        files: [
+          {
+            path: `components/watermelon/${slug}.tsx`,
+            type: 'registry:component',
+            content: base,
+          },
+        ],
+      });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+
+  return items;
+}
+
+export async function generateShadcnRegistry(
+  outputDirectory = OUTPUT_DIRECTORY,
+  manifestPath = REGISTRY_MANIFEST_PATH,
+) {
+  const items = await buildRegistryItems();
+
+  await rm(outputDirectory, { recursive: true, force: true });
+  await mkdir(outputDirectory, { recursive: true });
+
+  await Promise.all(
+    items.map((item) =>
+      writeFile(
+        path.join(outputDirectory, `${item.name}.json`),
+        `${JSON.stringify(item, null, 2)}\n`,
+      ),
+    ),
+  );
+
+  const manifest = {
+    $schema: 'https://ui.shadcn.com/schema/registry.json',
+    name: 'watermelon',
+    homepage: 'https://ui.watermelon.sh',
+    items,
+  };
+
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  return { items, manifest };
+}
+
+if (import.meta.main) {
+  const { items } = await generateShadcnRegistry();
+  console.log(`Generated ${items.length} Watermelon shadcn registry items.`);
+}

--- a/src/pages/developers-mcp.tsx
+++ b/src/pages/developers-mcp.tsx
@@ -63,6 +63,28 @@ export default function DevelopersMcpPage() {
           </DocText>
         </DocSection>
 
+        <DocSection title="Usage Analytics And Privacy">
+          <DocText>
+            Watermelon records aggregate MCP handshake and tool-call counts to
+            understand service health and improve the public catalog. The
+            telemetry does not store IP addresses, session IDs, prompts, tool
+            arguments, or client-provided version strings. Client names are
+            reduced to broad categories such as <code>chatgpt</code>,{' '}
+            <code>claude</code>, <code>cursor</code>, <code>codex</code>, or{' '}
+            <code>other</code>.
+          </DocText>
+          <DocText>
+            Check the{' '}
+            <a
+              href="https://mcp.watermelon.sh/health"
+              className="bg-muted rounded-sm px-2 py-px text-black dark:text-white"
+            >
+              MCP health endpoint
+            </a>{' '}
+            for the current public service and analytics configuration.
+          </DocText>
+        </DocSection>
+
         <DocSection title="ChatGPT And Claude">
           <DocText>
             Watermelon MCP is designed for MCP-compatible clients that support

--- a/wrangler.mcp.toml
+++ b/wrangler.mcp.toml
@@ -3,6 +3,10 @@ main = "./mcp/worker.ts"
 compatibility_date = "2026-08-30"
 workers_dev = true
 
+[[analytics_engine_datasets]]
+binding = "MCP_ANALYTICS"
+dataset = "watermelon_mcp_events"
+
 [[routes]]
 pattern = "mcp.watermelon.sh"
 zone_name = "watermelon.sh"


### PR DESCRIPTION
## What changed\n- records privacy-safe aggregate MCP initialize and tool-call metrics in Cloudflare Analytics Engine\n- generates 262 shadcn-compatible Watermelon registry items during platform builds\n- adds a publish-ready @watermelon-ui/cli package and manual npm release workflow\n- documents MCP telemetry and component installation\n\n## Verification\n- bun test mcp/worker.test.ts scripts/generate-shadcn-registry.test.ts\n- bun run lint\n- bunx wrangler deploy --dry-run --config wrangler.mcp.toml\n- npm pack --dry-run (packages/cli)\n- production preview served registry item as application/json\n\n## Follow-up\n- add the NPM_TOKEN repository secret and publish @watermelon-ui/cli after the registry endpoint is live\n- submit @watermelon to the shadcn community registry directory once the deployed URL has been verified