### PR TITLE
Route shadcn registry subdomain to platform worker

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,3 +7,8 @@ directory = "./dist"
 binding = "ASSETS"
 not_found_handling = "404-page"
 run_worker_first = true
+
+[[routes]]
+pattern = "registry.watermelon.sh"
+zone_name = "watermelon.sh"
+custom_domain = true


### PR DESCRIPTION
Routes registry.watermelon.sh to the platform Worker so generated shadcn registry JSON is served instead of the SPA HTML shell.\n\nVerification: bunx wrangler deploy --dry-run --config wrangler.toml.