### PR TITLE
fix: route UI hostname to platform worker

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,3 +12,8 @@ run_worker_first = true
 pattern = "registry.watermelon.sh"
 zone_name = "watermelon.sh"
 custom_domain = true
+
+[[routes]]
+pattern = "ui.watermelon.sh"
+zone_name = "watermelon.sh"
+custom_domain = true


### PR DESCRIPTION
## Summary

Restores `ui.watermelon.sh` as a Cloudflare custom domain for the platform Worker. The hostname was resolving through Cloudflare to an obsolete Vercel deployment, causing `DEPLOYMENT_NOT_FOUND`.

## Verification

- Cloudflare Worker deployment configuration validates with `bunx wrangler deploy --dry-run --config wrangler.toml --name watermelon-platform`.
- After deployment, `https://ui.watermelon.sh/` will be verified to return the platform application rather than Vercel error `DEPLOYMENT_NOT_FOUND`.