### PR TITLE
perf: lazy-load component previews

### DIFF
--- a/src/components/application-error-boundary.tsx
+++ b/src/components/application-error-boundary.tsx
@@ -1,0 +1,60 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface ApplicationErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ApplicationErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ApplicationErrorBoundary extends Component<
+  ApplicationErrorBoundaryProps,
+  ApplicationErrorBoundaryState
+> {
+  state: ApplicationErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ApplicationErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('Watermelon UI failed to render.', error, info);
+  }
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-neutral-950 px-6 text-neutral-50">
+        <div className="w-full max-w-lg rounded-3xl border border-white/10 bg-neutral-900 p-8 shadow-2xl">
+          <p className="mb-3 text-sm font-medium text-lime-400">Watermelon UI</p>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            This page could not finish loading
+          </h1>
+          <p className="mt-3 text-sm leading-6 text-neutral-400">
+            Your catalog is safe. Reload the page, or use the component index
+            while we recover this view.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="rounded-xl bg-lime-400 px-4 py-2 text-sm font-medium text-neutral-950 hover:bg-lime-300"
+            >
+              Reload page
+            </button>
+            <a
+              href="/animated-components"
+              className="rounded-xl border border-white/10 px-4 py-2 text-sm font-medium hover:bg-white/5"
+            >
+              Browse components
+            </a>
+          </div>
+        </div>
+      </main>
+    );
+  }
+}

--- a/src/components/layout/page-layout.tsx
+++ b/src/components/layout/page-layout.tsx
@@ -49,7 +49,7 @@ export function PageLayout({
       <ScrollProgressContainer
         ref={containerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto rounded-xl m-2 bg-white dark:bg-background border md:m-0"
+        className="m-2 min-w-0 flex-1 overflow-x-hidden overflow-y-auto rounded-xl border bg-white md:m-0 dark:bg-background"
       >
         {showNavbar && <Navbar />}
 

--- a/src/components/registry/registry-card.tsx
+++ b/src/components/registry/registry-card.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, memo } from "react";
 import type { RegistryItem } from "@/data/animated-components-registry";
 import { cn } from "@/lib/utils";
 import { trackEvent } from "@/lib/analytics";
+import { ResilientImage } from "@/components/ui/resilient-image";
 
 interface RegistryCardProps {
   item: RegistryItem;
@@ -28,7 +29,10 @@ interface RegistryCardProps {
 
 export const RegistryCard = memo(function RegistryCard({ item, onClick }: RegistryCardProps) {
   const [isHovered, setIsHovered] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+  const [isVideoReady, setIsVideoReady] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
+  const shouldLoadVideo = Boolean(item.video && (isHovered || isFocused));
 
   // Get the CLI command from item.install (same as component-modal)
   // const cliCommand = item.install?.[0] || `npx shadcn@latest add ${item.slug}`;
@@ -42,14 +46,12 @@ export const RegistryCard = memo(function RegistryCard({ item, onClick }: Regist
     // Safari fix: ensure muted property is set on the DOM element
     video.muted = true;
 
-    if (isHovered) {
+    if (shouldLoadVideo && isVideoReady) {
       video.play().catch(() => { });
     } else {
       video.pause();
-      // Reset to our poster frame mark so it stays seamless when unhovered
-      video.currentTime = 0.001;
     }
-  }, [isHovered]);
+  }, [shouldLoadVideo, isVideoReady]);
 
   // const handleCopy = async (e: React.MouseEvent) => {
   //   e.stopPropagation();
@@ -69,9 +71,8 @@ export const RegistryCard = memo(function RegistryCard({ item, onClick }: Regist
   // };
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
+    <button
+      type="button"
       onClick={() => {
         trackEvent("component_card_click", {
           component_slug: item.slug,
@@ -81,9 +82,17 @@ export const RegistryCard = memo(function RegistryCard({ item, onClick }: Regist
         onClick(item);
       }}
       onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      onMouseLeave={() => {
+        setIsHovered(false);
+        setIsVideoReady(false);
+      }}
+      onFocus={() => setIsFocused(true)}
+      onBlur={() => {
+        setIsFocused(false);
+        setIsVideoReady(false);
+      }}
       className={cn(
-        "group relative cursor-pointer",
+        "group relative w-full cursor-pointer text-left",
         "rounded-4xl p-2",
         // Light mode: subtle gray background with soft border
         "bg-gray-100",
@@ -146,32 +155,41 @@ export const RegistryCard = memo(function RegistryCard({ item, onClick }: Regist
           pointer-events-none z-10"
         />
 
-        {/* Static image (only if no video is available) */}
-        {/* {!item.video && item.image && (
-          <img
+        {item.image ? (
+          <ResilientImage
             src={item.image}
-            srcSet={getImageSrcSet(item.image)}
-            sizes="(min-width: 1280px) 31vw, (min-width: 768px) 48vw, 96vw"
             alt={`${item.name} preview`}
-            loading={imagePriority ? "eager" : "lazy"}
-            fetchPriority={imagePriority ? "high" : "auto"}
+            loading="lazy"
             decoding="async"
-            className="absolute inset-0 h-full w-full object-cover"
+            className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+            fallback={
+              <div className="text-muted-foreground absolute inset-0 flex items-center justify-center p-6 text-center text-sm">
+                {item.name} preview
+              </div>
+            }
           />
-        )} */}
+        ) : (
+          <div className="text-muted-foreground absolute inset-0 flex items-center justify-center p-6 text-center text-sm">
+            {item.name} preview
+          </div>
+        )}
 
-        {/* Video preview */}
-        {item.video && (
+        {shouldLoadVideo && (
           <video
             ref={videoRef}
-            src={`${item.video}#t=0.001`} // this line is used for play video on specific time and also create the poster
+            src={item.video}
             muted
             loop
             playsInline
             preload="metadata"
+            onLoadedData={() => setIsVideoReady(true)}
+            onError={() => setIsVideoReady(false)}
             aria-hidden="true"
             tabIndex={-1}
-            className="absolute inset-0 h-full w-full object-cover"
+            className={cn(
+              "absolute inset-0 h-full w-full object-cover transition-opacity duration-200",
+              isVideoReady ? "opacity-100" : "opacity-0",
+            )}
           />
         )}
 
@@ -184,6 +202,6 @@ export const RegistryCard = memo(function RegistryCard({ item, onClick }: Regist
           pointer-events-none z-10"
         /> */}
       </div>
-    </div>
+    </button>
   );
 })

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -308,7 +308,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-gray-100 dark:bg-neutral-900 md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 relative flex w-full flex-1 flex-col",
+        "bg-gray-100 dark:bg-neutral-900 md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 relative flex min-w-0 flex-1 flex-col",
         className,
       )}
       {...props}

--- a/src/data/animated-components-registry.tsx
+++ b/src/data/animated-components-registry.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 
+type ComponentModule = {
+  default: React.ComponentType<any>;
+};
+
+type ComponentLoader = () => Promise<ComponentModule>;
+type SourceLoader = () => Promise<string>;
+
 export interface RegistryItem {
   name: string;
   slug: string;
@@ -33,46 +40,59 @@ export interface RegistryItem {
 // Load all MDX files (metadata)
 const mdxFiles = import.meta.glob("./contents/registry/*.mdx", { eager: true });
 
-// Load all Component Demos (eager) - from subfolders
-const demoBaseComponents = import.meta.glob("./contents/animated-components/*/demo-base.tsx", { eager: true });
-const demoOriginalComponents = import.meta.glob("./contents/animated-components/*/demo-original.tsx", { eager: true });
-const demoOldComponents = import.meta.glob("./contents/animated-components/*/demo.tsx", { eager: true });
+// Keep demos and source files out of the initial bundle. They are fetched only
+// when a user opens a component preview or requests its source.
+const demoBaseComponents = import.meta.glob<ComponentModule>(
+  "./contents/animated-components/*/demo-base.tsx",
+);
+const demoOriginalComponents = import.meta.glob<ComponentModule>(
+  "./contents/animated-components/*/demo-original.tsx",
+);
+const demoOldComponents = import.meta.glob<ComponentModule>(
+  "./contents/animated-components/*/demo.tsx",
+);
 
 // Load all Component Source Code (eager) - from subfolders
-const componentBaseSource = import.meta.glob("./contents/animated-components/*/base.tsx", {
+const componentBaseSource = import.meta.glob<string>("./contents/animated-components/*/base.tsx", {
   query: "?raw",
   import: "default",
-  eager: true,
 });
 
-const componentOriginalSource = import.meta.glob("./contents/animated-components/*/original.tsx", {
+const componentOriginalSource = import.meta.glob<string>("./contents/animated-components/*/original.tsx", {
   query: "?raw",
   import: "default",
-  eager: true,
 });
 
-const componentOldSource = import.meta.glob("./contents/animated-components/*/index.tsx", {
+const componentOldSource = import.meta.glob<string>("./contents/animated-components/*/index.tsx", {
   query: "?raw",
   import: "default",
-  eager: true,
 });
 
 // Load all Component Demo Source Code (eager) - from subfolders
-const demoBaseSource = import.meta.glob("./contents/animated-components/*/demo-base.tsx", {
+const demoBaseSource = import.meta.glob<string>("./contents/animated-components/*/demo-base.tsx", {
   query: "?raw",
   import: "default",
-  eager: true,
 });
-const demoOriginalSource = import.meta.glob("./contents/animated-components/*/demo-original.tsx", {
+const demoOriginalSource = import.meta.glob<string>("./contents/animated-components/*/demo-original.tsx", {
   query: "?raw",
   import: "default",
-  eager: true,
 });
-const demoOldSource = import.meta.glob("./contents/animated-components/*/demo.tsx", {
+const demoOldSource = import.meta.glob<string>("./contents/animated-components/*/demo.tsx", {
   query: "?raw",
   import: "default",
-  eager: true,
 });
+
+const MissingComponent = () => <div>Component preview unavailable</div>;
+
+function lazyComponent(loader?: ComponentLoader) {
+  return React.lazy(
+    loader ?? (async () => ({ default: MissingComponent })),
+  );
+}
+
+function lazySource(loader: SourceLoader | undefined, fallback: string) {
+  return loader ?? (async () => fallback);
+}
 
 export const registry: RegistryItem[] = Object.values(mdxFiles)
   .map((mod: any) => {
@@ -93,8 +113,8 @@ export const registry: RegistryItem[] = Object.values(mdxFiles)
     const originalKey = `./contents/animated-components/${slug}/original.tsx`;
     const indexKey = `./contents/animated-components/${slug}/index.tsx`;
 
-    const demoBaseModule = demoBaseComponents[demoBaseKey] || demoOldComponents[demoOldKey];
-    const demoOriginalModule = demoOriginalComponents[demoOriginalKey] || demoOldComponents[demoOldKey];
+    const demoBaseLoader = demoBaseComponents[demoBaseKey] || demoOldComponents[demoOldKey];
+    const demoOriginalLoader = demoOriginalComponents[demoOriginalKey] || demoOldComponents[demoOldKey];
     
     const baseCode = componentBaseSource[baseKey];
     const originalCode = componentOriginalSource[originalKey] || componentOldSource[indexKey];
@@ -106,16 +126,16 @@ export const registry: RegistryItem[] = Object.values(mdxFiles)
       ...frontmatter,
       name: frontmatter.title,
       component: {
-        base: (demoBaseModule as any)?.default || (() => <div>Missing Base Component</div>),
-        original: (demoOriginalModule as any)?.default || (() => <div>Missing Original Component</div>)
+        base: lazyComponent(demoBaseLoader),
+        original: lazyComponent(demoOriginalLoader),
       },
       code: {
-        base: async () => (baseCode as string) || `// Missing base code for ${slug}`,
-        original: async () => (originalCode as string) || `// Missing original code for ${slug}`
+        base: lazySource(baseCode, `// Missing base code for ${slug}`),
+        original: lazySource(originalCode, `// Missing original code for ${slug}`),
       },
       demoCode: {
-        base: async () => (demoCodeBase as string) || `// Missing demo base code for ${slug}`,
-        original: async () => (demoCodeOriginal as string) || `// Missing demo original code for ${slug}`
+        base: lazySource(demoCodeBase, `// Missing demo base code for ${slug}`),
+        original: lazySource(demoCodeOriginal, `// Missing demo original code for ${slug}`),
       },
       category: frontmatter.category || "Uncategorized",
       description: frontmatter.description || "",

--- a/src/data/ui-category-metadata.ts
+++ b/src/data/ui-category-metadata.ts
@@ -1,0 +1,47 @@
+export interface UiCategoryMetadata {
+  slug: string;
+  label: string;
+  description: string;
+  count: number;
+}
+
+type CategoryConfigModule = {
+  category?: {
+    slug: string;
+    label: string;
+    description: string;
+  };
+};
+
+const categoryConfigs = import.meta.glob<CategoryConfigModule>(
+  './contents/components/*/config.ts',
+  { eager: true },
+);
+
+// Vite only records loaders here, so the home page can count variants without
+// pulling hundreds of component implementations into its initial bundle.
+const variantModules = import.meta.glob(
+  './contents/components/*/variant-*.tsx',
+);
+
+const variantCounts = Object.keys(variantModules).reduce<Record<string, number>>(
+  (counts, path) => {
+    const slug = path.split('/').at(-2);
+    if (slug) counts[slug] = (counts[slug] ?? 0) + 1;
+    return counts;
+  },
+  {},
+);
+
+export const uiCategoryMetadata = Object.values(categoryConfigs)
+  .map((module) => module.category)
+  .filter((category): category is NonNullable<typeof category> =>
+    Boolean(category?.slug && category.label),
+  )
+  .map((category) => ({
+    ...category,
+    count: variantCounts[category.slug] ?? 0,
+  }))
+  .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+
+export const uiVariantCount = Object.keys(variantModules).length;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { PostHogProvider } from '@posthog/react'
 import './index.css'
 import App from './App.tsx'
+import { ApplicationErrorBoundary } from './components/application-error-boundary.tsx'
 
 const root = document.getElementById('root')
 if (!root) {
@@ -56,13 +57,15 @@ async function bootstrap() {
 
   createRoot(root!).render(
     <StrictMode>
-      {enablePosthog ? (
-        <PostHogProvider apiKey={posthogKey} options={options}>
+      <ApplicationErrorBoundary>
+        {enablePosthog ? (
+          <PostHogProvider apiKey={posthogKey} options={options}>
+            <App />
+          </PostHogProvider>
+        ) : (
           <App />
-        </PostHogProvider>
-      ) : (
-        <App />
-      )}
+        )}
+      </ApplicationErrorBoundary>
     </StrictMode>
   )
 }

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,54 +1,224 @@
-import { useState, Suspense, lazy } from 'react';
+import { lazy, Suspense, useDeferredValue, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { HugeiconsIcon } from '@hugeicons/react';
+import {
+  ArrowRight01Icon,
+  SearchIcon,
+  SparklesIcon,
+} from '@/lib/hugeicons';
 import {
   registry,
   type RegistryItem,
 } from '@/data/animated-components-registry';
-import type { DashboardItem } from '@/data/dashboards';
-import type { BlockItem } from '@/data/blocks';
-import { blockCategories } from '@/data/block-metadata';
-import { cn } from '@/lib/utils';
-import { SEOHead } from '@/components/seo-head';
+import { blockCategories, blockMetadata } from '@/data/block-metadata';
+import { dashboardMetadata } from '@/data/dashboard-metadata';
+import { showcaseMetadata } from '@/data/showcase-metadata';
+import {
+  uiCategoryMetadata,
+  uiVariantCount,
+} from '@/data/ui-category-metadata';
 import { RegistryCard } from '@/components/registry/registry-card';
-// import { DashboardCard } from '@/components/registry/dashboard-card';
-import { Link } from 'react-router-dom';
-import { HugeiconsIcon } from '@hugeicons/react';
-import { ArrowRight01Icon } from '@/lib/hugeicons';
-import { trackEvent } from '@/lib/analytics';
-import DashboardFooter from '@/components/layout/dashboard-footer';
 import { ResilientImage } from '@/components/ui/resilient-image';
+import { SEOHead } from '@/components/seo-head';
+import DashboardFooter from '@/components/layout/dashboard-footer';
+import { cn } from '@/lib/utils';
+import { trackEvent } from '@/lib/analytics';
+
+const templateFiles = import.meta.glob('../data/contents/templates/**/*.mdx');
 
 const ComponentModal = lazy(() =>
-  import('@/components/registry/component-modal').then((m) => ({
-    default: m.ComponentModal,
+  import('@/components/registry/component-modal').then((module) => ({
+    default: module.ComponentModal,
   })),
 );
-const DashboardModal = lazy(() =>
-  import('@/components/registry/dashboard-modal').then((m) => ({
-    default: m.DashboardModal,
-  })),
-);
-const BlockModal = lazy(() =>
-  import('@/components/registry/block-modal').then((m) => ({
-    default: m.BlockModal,
-  })),
-);
+
+interface SectionHeadingProps {
+  eyebrow: string;
+  title: string;
+  description: string;
+  href: string;
+  linkLabel?: string;
+}
+
+function SectionHeading({
+  eyebrow,
+  title,
+  description,
+  href,
+  linkLabel = 'View all',
+}: SectionHeadingProps) {
+  return (
+    <div className="flex items-end justify-between gap-5">
+      <div className="max-w-2xl space-y-1.5">
+        <p className="text-primary text-[11px] font-semibold tracking-[0.2em] uppercase">
+          {eyebrow}
+        </p>
+        <h2 className="text-xl font-semibold tracking-tight md:text-2xl">{title}</h2>
+        <p className="text-muted-foreground text-sm leading-relaxed">{description}</p>
+      </div>
+      <Link
+        to={href}
+        className="text-muted-foreground hover:text-foreground hidden shrink-0 items-center gap-1 text-sm font-medium transition-colors sm:flex"
+      >
+        {linkLabel}
+        <HugeiconsIcon icon={ArrowRight01Icon} size={16} />
+      </Link>
+    </div>
+  );
+}
+
+function ComponentRail({
+  items,
+  onSelect,
+}: {
+  items: RegistryItem[];
+  onSelect: (item: RegistryItem) => void;
+}) {
+  return (
+    <div className="scrollbar-hide -mx-4 grid snap-x grid-flow-col auto-cols-[82%] gap-4 overflow-x-auto px-4 pb-2 sm:auto-cols-[47%] md:-mx-6 md:px-6 lg:-mx-8 lg:grid-flow-row lg:grid-cols-4 lg:px-8">
+      {items.map((item) => (
+        <div key={item.slug} className="snap-start">
+          <RegistryCard item={item} onClick={onSelect} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function BlockCategoryCard({
+  category,
+}: {
+  category: (typeof blockCategories)[number];
+}) {
+  return (
+    <Link
+      to={`/blocks/${category.slug}`}
+      className="group bg-muted/65 border-border/70 block overflow-hidden rounded-3xl border p-1.5 no-underline transition duration-300 hover:-translate-y-0.5 hover:shadow-xl hover:shadow-black/5 dark:hover:shadow-black/20"
+    >
+      <div className="relative aspect-[16/11] overflow-hidden rounded-[18px] bg-white dark:bg-black">
+        {category.image ? (
+          <ResilientImage
+            src={category.image}
+            alt={`${category.label} block collection`}
+            loading="lazy"
+            decoding="async"
+            className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.03]"
+            fallback={
+              <div className="text-muted-foreground absolute inset-0 grid place-items-center text-sm">
+                {category.label}
+              </div>
+            }
+          />
+        ) : (
+          <div className="absolute inset-0 grid place-items-center bg-[radial-gradient(circle_at_30%_30%,color-mix(in_oklab,var(--primary)_28%,transparent),transparent_62%)]">
+            <span className="text-foreground/80 text-3xl font-semibold">
+              {category.label.slice(0, 2).toUpperCase()}
+            </span>
+          </div>
+        )}
+      </div>
+      <div className="flex items-center justify-between gap-3 px-3 py-3">
+        <span className="truncate text-sm font-medium">{category.label}</span>
+        <span className="text-muted-foreground shrink-0 text-xs">
+          {category.count} blocks
+        </span>
+      </div>
+    </Link>
+  );
+}
+
+const collectionCards = [
+  {
+    label: 'Animated',
+    description: 'Motion-first interactions and effects.',
+    href: '/animated-components',
+    accent: 'from-lime-300/45 via-lime-200/10 to-transparent',
+  },
+  {
+    label: 'Components',
+    description: 'Production-ready interface primitives.',
+    href: '/components',
+    accent: 'from-emerald-300/40 via-emerald-200/10 to-transparent',
+  },
+  {
+    label: 'Blocks',
+    description: 'Complete sections for real product pages.',
+    href: '/blocks',
+    accent: 'from-amber-300/40 via-amber-200/10 to-transparent',
+  },
+  {
+    label: 'Dashboards',
+    description: 'Data-rich application layouts.',
+    href: '/dashboards',
+    accent: 'from-sky-300/40 via-sky-200/10 to-transparent',
+  },
+  {
+    label: 'Showcases',
+    description: 'Finished compositions made with Watermelon.',
+    href: '/showcases',
+    accent: 'from-rose-300/40 via-rose-200/10 to-transparent',
+  },
+  {
+    label: 'Templates',
+    description: 'Full starting points ready to customize.',
+    href: '/templates',
+    accent: 'from-orange-300/40 via-orange-200/10 to-transparent',
+  },
+];
 
 export default function HomePage() {
   const [selectedItem, setSelectedItem] = useState<RegistryItem | null>(null);
-  const [selectedDashboard, setSelectedDashboard] =
-    useState<DashboardItem | null>(null);
-  const [selectedBlock, setSelectedBlock] = useState<BlockItem | null>(null);
+  const [query, setQuery] = useState('');
+  const deferredQuery = useDeferredValue(query.trim().toLowerCase());
 
-  // For home page, we might want to show featured or all. Let's show all for now.
-  // In a real app, you might have a "featured" flag.
-  const featuredItems = registry.slice(0, 6);
-  const featuredBlocks = blockCategories.slice(0, 6);
+  const templateCount = Object.keys(templateFiles).length;
+  const collectionCounts = [
+    registry.length,
+    uiVariantCount,
+    blockMetadata.length,
+    dashboardMetadata.length,
+    showcaseMetadata.length,
+    templateCount,
+  ];
+  const totalExamples = collectionCounts.reduce((sum, count) => sum + count, 0);
+  const animatedCategoryCounts = registry.reduce<Record<string, number>>(
+    (counts, item) => {
+      counts[item.category] = (counts[item.category] ?? 0) + 1;
+      return counts;
+    },
+    {},
+  );
+  const topAnimatedCategories = Object.entries(animatedCategoryCounts)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 10);
 
-  const renderBlockFallback = (label: string) => (
-    <div className="space-y-2 p-4 text-center">
-      <div className="text-4xl">🧩</div>
-      <p className="text-sm font-medium text-neutral-500">{label}</p>
-    </div>
+  const matchingComponents = deferredQuery
+    ? registry
+        .filter((item) =>
+          `${item.name} ${item.category} ${item.description}`
+            .toLowerCase()
+            .includes(deferredQuery),
+        )
+        .slice(0, 18)
+    : [];
+  const matchingBlocks = deferredQuery
+    ? blockCategories.filter((category) =>
+        `${category.label} ${category.description}`
+          .toLowerCase()
+          .includes(deferredQuery),
+      )
+    : [];
+  const matchingUiCategories = deferredQuery
+    ? uiCategoryMetadata.filter((category) =>
+        `${category.label} ${category.description}`
+          .toLowerCase()
+          .includes(deferredQuery),
+      )
+    : [];
+  const hasSearchResults = Boolean(
+    matchingComponents.length ||
+      matchingBlocks.length ||
+      matchingUiCategories.length,
   );
 
   const organizationSchema = JSON.stringify({
@@ -57,176 +227,243 @@ export default function HomePage() {
     name: 'Watermelon UI',
     url: 'https://ui.watermelon.sh',
     logo: 'https://ui.watermelon.sh/logo.png',
-    foundingDate: '2024-01-01',
     description:
-      'A collection of high-quality React components for modern web applications.',
-    contactPoint: {
-      '@type': 'ContactPoint',
-      contactType: 'support',
-      email: 'watermeloncorpui@gmail.com',
-    },
-    address: {
-      '@type': 'PostalAddress',
-      addressCountry: 'US',
-    },
+      'An open-source catalog of React components, blocks, dashboards, and templates.',
   });
 
   return (
     <>
       <SEOHead
-        title="React Components, Dashboards & Blocks"
-        description="Explore our collection of high-quality, customizable React components built with modularity and performance in mind."
+        title="React UI Components, Blocks and Templates"
+        description={`Explore ${totalExamples}+ open-source React components, animated interactions, blocks, dashboards, showcases, and templates.`}
         schema={organizationSchema}
         image="/og-image.avif"
       />
 
-      <h1 className="sr-only">
-        Watermelon UI - High-Quality React Components Registry
-      </h1>
+      <div className="flex min-w-0 flex-1 flex-col overflow-x-clip">
+        <section className="relative isolate overflow-hidden border-b px-4 py-12 md:px-6 md:py-16 lg:px-8 lg:py-20">
+          <div className="bg-primary/20 pointer-events-none absolute -top-28 left-[12%] -z-10 h-72 w-72 rounded-full blur-[110px]" />
+          <div className="pointer-events-none absolute right-[4%] bottom-0 -z-10 h-52 w-80 bg-[radial-gradient(ellipse_at_center,color-mix(in_oklab,var(--primary)_18%,transparent),transparent_68%)]" />
 
-      <div className="flex flex-1 flex-col gap-12">
-        {/* Components Section */}
-        <section id="components" className="flex flex-col gap-6">
-          <h2 className="px-4 pt-4 pl-5 text-lg font-medium tracking-tight md:px-8 md:pl-7 md:text-xl lg:px-8 lg:pl-9">
-            Featured Components
-          </h2>
+          <div className="mx-auto max-w-5xl text-center">
+            <div className="border-primary/20 bg-primary/8 text-primary mx-auto mb-5 flex w-fit items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium">
+              <HugeiconsIcon icon={SparklesIcon} size={14} />
+              Built in the open, free for the community
+            </div>
+            <h1 className="text-balance text-4xl leading-[0.98] font-semibold tracking-[-0.045em] md:text-6xl lg:text-7xl">
+              Find the piece that makes your interface click.
+            </h1>
+            <p className="text-muted-foreground mx-auto mt-5 max-w-2xl text-pretty text-base leading-relaxed md:text-lg">
+              Browse a growing React catalog from tiny interactions to complete
+              product pages, with source-backed examples ready to build on.
+            </p>
 
-          <div className="grid grid-cols-1 gap-6 px-4 md:grid-cols-2 md:px-6 lg:grid-cols-3 lg:px-8">
-            {featuredItems.map((item) => (
-              <RegistryCard
-                key={item.slug}
-                item={item}
-                onClick={(item) => setSelectedItem(item)}
+            <label className="group border-border/80 bg-background/90 focus-within:border-primary/60 focus-within:ring-primary/15 mx-auto mt-8 flex max-w-2xl items-center gap-3 rounded-2xl border p-2 pl-4 shadow-xl shadow-black/5 backdrop-blur-xl transition focus-within:ring-4 dark:shadow-black/20">
+              <HugeiconsIcon
+                icon={SearchIcon}
+                size={20}
+                className="text-muted-foreground group-focus-within:text-primary transition-colors"
               />
-            ))}
-          </div>
+              <span className="sr-only">Search the Watermelon catalog</span>
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search components, blocks, categories..."
+                className="placeholder:text-muted-foreground/70 min-w-0 flex-1 bg-transparent py-2.5 text-sm outline-none md:text-base"
+              />
+              <span className="text-muted-foreground bg-muted hidden rounded-lg px-2 py-1 font-mono text-[11px] sm:block">
+                {totalExamples}+
+              </span>
+            </label>
 
-          <h2 className="mt-8 px-4 pl-5 text-lg font-medium tracking-tight md:mt-12 md:px-8 md:pl-7 md:text-xl lg:px-8 lg:pl-9">
-            Featured Blocks
-          </h2>
-
-          <div className="grid grid-cols-1 gap-6 px-4 md:grid-cols-2 md:px-6 lg:grid-cols-3 lg:px-8">
-            {featuredBlocks.map((cat) => (
-              <Link
-                key={cat.slug}
-                to={`/blocks/${cat.slug}`}
-                id={`block-category-${cat.slug}`}
-                className={cn(
-                  'group relative block cursor-pointer no-underline',
-                  'rounded-4xl p-2',
-                  'bg-gray-100',
-                  'dark:border-0 dark:bg-neutral-800',
-                  'backdrop-blur-xl backdrop-saturate-150',
-                  'shadow-[inset_0_1px_0_0_var(--color-gray-200),inset_0_2px_0_0_rgba(255,255,255,1)]',
-                  'dark:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.2)]',
-                  'transition-all duration-300',
-                  'focus-visible:ring-primary focus-visible:ring-2 focus-visible:outline-none',
-                )}
-              >
-                {/* Header */}
-                <div className="relative z-10 flex items-center justify-between gap-4 px-2 pt-2 pb-3">
-                  <span className="text-foreground truncate text-base leading-tight font-medium">
-                    {cat.label}
-                  </span>
-                  <span className="text-muted-foreground text-sm capitalize">
-                    {cat.count} {cat.count === 1 ? 'block' : 'blocks'}
-                  </span>
-                </div>
-
-                {/* Preview */}
-                <div
-                  className={cn(
-                    'relative aspect-4/3 w-full overflow-hidden rounded-[20px]',
-                    'bg-muted',
-                    'border border-neutral-200/50 dark:border-white/5',
-                    'shadow-[inset_0_2px_4px_0_rgba(0,0,0,0.05)]',
-                    'dark:shadow-[inset_0_2px_4px_0_rgba(0,0,0,0.2)]',
-                  )}
+            <div className="mt-5 flex flex-wrap items-center justify-center gap-2">
+              {topAnimatedCategories.slice(0, 7).map(([category, count]) => (
+                <Link
+                  key={category}
+                  to={`/animated-components/category/${encodeURIComponent(category.toLowerCase())}`}
+                  className="border-border/70 bg-background/65 text-muted-foreground hover:border-primary/40 hover:text-foreground rounded-full border px-3 py-1.5 text-xs transition"
                 >
-                  <div
-                    aria-hidden
-                    className="pointer-events-none absolute inset-0 z-10 rounded-[20px] ring-1 ring-white/20 ring-inset dark:ring-white/5"
-                  />
+                  {category} <span className="text-foreground/45 ml-1">{count}</span>
+                </Link>
+              ))}
+            </div>
 
-                  <div className="absolute inset-0 flex items-center justify-center bg-white transition-colors duration-300 dark:bg-black">
-                    {cat.image ? (
-                      <ResilientImage
-                        src={cat.image}
-                        alt={`${cat.label} preview`}
-                        loading="lazy"
-                        decoding="async"
-                        className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-                        fallback={renderBlockFallback(cat.label)}
-                      />
-                    ) : (
-                      renderBlockFallback(cat.label)
-                    )}
-                  </div>
-                </div>
-              </Link>
-            ))}
+            <div className="border-border/70 mx-auto mt-9 grid max-w-2xl grid-cols-3 divide-x rounded-2xl border bg-black/[0.02] py-4 dark:bg-white/[0.025]">
+              <div>
+                <p className="text-xl font-semibold tracking-tight md:text-2xl">{totalExamples}+</p>
+                <p className="text-muted-foreground mt-0.5 text-[11px] tracking-wider uppercase">Examples</p>
+              </div>
+              <div>
+                <p className="text-xl font-semibold tracking-tight md:text-2xl">{uiCategoryMetadata.length + blockCategories.length}</p>
+                <p className="text-muted-foreground mt-0.5 text-[11px] tracking-wider uppercase">Categories</p>
+              </div>
+              <div>
+                <p className="text-xl font-semibold tracking-tight md:text-2xl">6</p>
+                <p className="text-muted-foreground mt-0.5 text-[11px] tracking-wider uppercase">Collections</p>
+              </div>
+            </div>
           </div>
         </section>
 
-        <div className="flex items-center justify-center gap-3 px-4 py-1 md:px-6 lg:px-8">
-          {/* Left: line + two crosses */}
-          <div className="flex flex-1 items-center justify-end gap-2.5">
-            <div className="from-foreground/20 h-px flex-1 bg-linear-to-l to-transparent" />
-            <span className="text-foreground/20 text-base leading-none select-none">
-              ×
-            </span>
-            <span className="text-foreground/20 text-base leading-none select-none">
-              ×
-            </span>
+        {deferredQuery ? (
+          <section className="space-y-7 px-4 py-10 md:px-6 lg:px-8">
+            <div>
+              <p className="text-primary text-[11px] font-semibold tracking-[0.2em] uppercase">Search</p>
+              <h2 className="mt-1 text-2xl font-semibold tracking-tight">
+                Results for "{query.trim()}"
+              </h2>
+            </div>
+
+            {hasSearchResults ? (
+              <>
+                {(matchingUiCategories.length > 0 || matchingBlocks.length > 0) && (
+                  <div className="flex flex-wrap gap-2">
+                    {matchingUiCategories.map((category) => (
+                      <Link
+                        key={`ui-${category.slug}`}
+                        to={`/components/${category.slug}`}
+                        className="bg-muted hover:bg-accent rounded-full px-4 py-2 text-sm transition"
+                      >
+                        {category.label} <span className="text-muted-foreground">{category.count}</span>
+                      </Link>
+                    ))}
+                    {matchingBlocks.map((category) => (
+                      <Link
+                        key={`block-${category.slug}`}
+                        to={`/blocks/${category.slug}`}
+                        className="bg-muted hover:bg-accent rounded-full px-4 py-2 text-sm transition"
+                      >
+                        {category.label} <span className="text-muted-foreground">{category.count}</span>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+                {matchingComponents.length > 0 && (
+                  <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+                    {matchingComponents.map((item) => (
+                      <RegistryCard key={item.slug} item={item} onClick={setSelectedItem} />
+                    ))}
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className="border-border bg-muted/30 rounded-3xl border border-dashed px-6 py-16 text-center">
+                <p className="font-medium">No catalog matches yet.</p>
+                <p className="text-muted-foreground mt-1 text-sm">Try a broader term like button, hero, card, or menu.</p>
+              </div>
+            )}
+          </section>
+        ) : (
+          <div className="space-y-16 py-12 md:space-y-20 md:py-16">
+            <section className="space-y-6 px-4 md:px-6 lg:px-8">
+              <SectionHeading
+                eyebrow="Popular now"
+                title="Interactions worth stealing"
+                description="Our most distinctive motion patterns, ready to inspect, copy, and adapt. Video previews only load when you interact with a card."
+                href="/animated-components"
+              />
+              <ComponentRail items={registry.slice(0, 4)} onSelect={setSelectedItem} />
+            </section>
+
+            <section className="space-y-6 px-4 md:px-6 lg:px-8">
+              <SectionHeading
+                eyebrow="More motion"
+                title="Small details, big personality"
+                description="A second series of focused interactions for navigation, feedback, storytelling, and product polish."
+                href="/animated-components"
+              />
+              <ComponentRail items={registry.slice(4, 8)} onSelect={setSelectedItem} />
+            </section>
+
+            <section className="space-y-6 px-4 md:px-6 lg:px-8">
+              <SectionHeading
+                eyebrow="Page building"
+                title="Start with a complete section"
+                description={`${blockMetadata.length} copy-paste blocks organized into practical product and marketing collections.`}
+                href="/blocks"
+              />
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                {blockCategories.slice(0, 8).map((category) => (
+                  <BlockCategoryCard key={category.slug} category={category} />
+                ))}
+              </div>
+            </section>
+
+            <section className="space-y-6 px-4 md:px-6 lg:px-8">
+              <SectionHeading
+                eyebrow="UI foundations"
+                title="Go deep on every primitive"
+                description={`${uiVariantCount} variants across the components teams reach for every day.`}
+                href="/components"
+              />
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
+                {uiCategoryMetadata.slice(0, 15).map((category, index) => (
+                  <Link
+                    key={category.slug}
+                    to={`/components/${category.slug}`}
+                    className={cn(
+                      'group border-border/70 hover:border-primary/40 relative min-h-28 overflow-hidden rounded-2xl border p-4 no-underline transition duration-300 hover:-translate-y-0.5',
+                      index === 0 && 'sm:col-span-2',
+                    )}
+                  >
+                    <div className="bg-primary/12 absolute -right-7 -bottom-8 h-24 w-24 rounded-full blur-2xl transition-transform duration-500 group-hover:scale-150" />
+                    <div className="relative flex h-full flex-col justify-between gap-5">
+                      <span className="text-sm font-medium">{category.label}</span>
+                      <span className="text-muted-foreground text-xs">{category.count} variants</span>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </section>
+
+            <section className="space-y-6 px-4 md:px-6 lg:px-8">
+              <SectionHeading
+                eyebrow="Everything in one place"
+                title="Choose your starting point"
+                description="Move from a single control to a complete application without leaving the Watermelon catalog."
+                href="/components"
+                linkLabel="Browse components"
+              />
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {collectionCards.map((collection, index) => (
+                  <Link
+                    key={collection.label}
+                    to={collection.href}
+                    onClick={() => trackEvent('home_collection_click', { collection: collection.label })}
+                    className="group border-border/70 bg-card relative min-h-44 overflow-hidden rounded-3xl border p-6 no-underline transition duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-black/5"
+                  >
+                    <div className={`absolute inset-0 bg-linear-to-br ${collection.accent}`} />
+                    <div className="relative flex h-full flex-col justify-between gap-8">
+                      <div className="flex items-start justify-between gap-4">
+                        <span className="border-foreground/10 bg-background/60 rounded-full border px-2.5 py-1 font-mono text-xs backdrop-blur">
+                          {String(index + 1).padStart(2, '0')}
+                        </span>
+                        <HugeiconsIcon
+                          icon={ArrowRight01Icon}
+                          size={20}
+                          className="transition-transform duration-300 group-hover:translate-x-1"
+                        />
+                      </div>
+                      <div>
+                        <div className="flex items-baseline justify-between gap-3">
+                          <h3 className="text-xl font-semibold tracking-tight">{collection.label}</h3>
+                          <span className="text-muted-foreground text-sm">{collectionCounts[index]}</span>
+                        </div>
+                        <p className="text-muted-foreground mt-1.5 text-sm">{collection.description}</p>
+                      </div>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </section>
           </div>
+        )}
 
-          <Link
-            to="/animated-components"
-            onClick={() =>
-              trackEvent('cta_view_all_click', {
-                section: 'components',
-              })
-            }
-            className="flex w-fit items-center justify-center rounded-xl border border-lime-500 bg-linear-to-b from-lime-400 to-lime-500 px-4 py-2 pr-2.5 text-sm text-white shadow-[inset_0_1px_0_0_rgba(255,255,255,0.4),0_2px_1px_0_rgba(0,0,0,0.04)] dark:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.6),0_2px_1px_0_rgba(0,0,0,0.04)]"
-          >
-            View all ({registry.length})
-            <HugeiconsIcon icon={ArrowRight01Icon} size={18} />
-          </Link>
-
-          {/* Right: two crosses + line */}
-          <div className="flex flex-1 items-center gap-2.5">
-            <span className="text-foreground/20 text-base leading-none select-none">
-              ×
-            </span>
-            <span className="text-foreground/20 text-base leading-none select-none">
-              ×
-            </span>
-            <div className="from-foreground/20 h-px flex-1 bg-linear-to-r to-transparent" />
-          </div>
-        </div>
-
-        <div className="mt-auto">
-          <DashboardFooter />
-        </div>
+        <DashboardFooter />
 
         <Suspense fallback={null}>
           {selectedItem && (
-            <ComponentModal
-              item={selectedItem}
-              onClose={() => setSelectedItem(null)}
-            />
-          )}
-          {selectedDashboard && (
-            <DashboardModal
-              item={selectedDashboard}
-              onClose={() => setSelectedDashboard(null)}
-            />
-          )}
-          {selectedBlock && (
-            <BlockModal
-              item={selectedBlock}
-              onClose={() => setSelectedBlock(null)}
-            />
+            <ComponentModal item={selectedItem} onClose={() => setSelectedItem(null)} />
           )}
         </Suspense>
       </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,7 +76,7 @@ export default defineConfig({
     },
   },
   build: {
-    target: 'es2022',
+    target: 'es2019',
     rollupOptions: {
       output: {
         manualChunks,


### PR DESCRIPTION
## Preview scope

This PR is intentionally open for review and is not merged into production.

## Changes

- Lazy-load animated component demos and source files.
- Render resilient image posters before loading preview video.
- Load video only on hover or keyboard focus.
- Compile for ES2019 embedded-browser compatibility.
- Add a visible application error boundary.

## Verification

- `bun run lint`
- `bun run build`
- Home renders in embedded Chromium and current Chrome.
- Zero video requests before interaction.
- Opening a card lazy-loads and renders its interactive demo.