### PR TITLE
Fix MCP production runtime metadata

### DIFF
--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Generate MCP catalog
         run: bun run generate:mcp-catalog
 
+      - name: Generate runtime metadata
+        run: bun run generate:ops
+
       - name: Deploy MCP Worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/mcp/worker.test.ts
+++ b/mcp/worker.test.ts
@@ -30,6 +30,7 @@ describe('mcp worker', () => {
     expect(body.ok).toBe(true);
     expect(body.service).toBe('watermelon-mcp');
     expect(body.transport).toBe('streamable-http');
+    expect(body.tools).toContain('get_component');
     expect(body.build.generatedAt).toBeTruthy();
   });
 

--- a/mcp/worker.ts
+++ b/mcp/worker.ts
@@ -172,6 +172,7 @@ export default {
           privacy: 'Aggregate event counts only. No IP addresses, session IDs, prompts, or tool arguments are stored.',
         },
         build: getRuntimeMetadata(),
+        tools: [...knownToolNames],
         ...getCatalogStats(),
       });
     }


### PR DESCRIPTION
## Summary
- regenerate runtime metadata in the MCP deploy workflow
- expose the supported tool list from the health endpoint
- test health tool discovery

## Verification
- `bun test mcp/worker.test.ts`
- `bunx tsc -b --pretty false`
- `bun run lint`