### PR TITLE
fix: keep Scroll Island within preview

### DIFF
--- a/src/data/contents/animated-components/scroll-island/base.tsx
+++ b/src/data/contents/animated-components/scroll-island/base.tsx
@@ -32,25 +32,25 @@ export function ScrollIsland({ topics }: ScrollIslandProps) {
   const [ref, bounds] = useMeasure({ offsetSize: true });
 
   const contentRef = useRef<HTMLDivElement>(null);
-
-  const isScrollIslandPage =
-    typeof window !== 'undefined' &&
-    window.location.pathname === '/components/scroll-island';
-
-  const [isMobile, setIsMobile] = useState(false);
-
-  useEffect(() => {
-    const check = () => setIsMobile(window.innerWidth < 768);
-    check();
-    window.addEventListener('resize', check);
-    return () => window.removeEventListener('resize', check);
-  }, []);
+  const [islandPosition, setIslandPosition] = useState({
+    left: 0,
+    top: 0,
+    width: 0,
+  });
 
   useEffect(() => {
     requestAnimationFrame(() => setMounted(true));
 
     const el = contentRef.current;
     if (!el) return;
+
+    const updatePosition = () => {
+      const { left, top, width } = el.getBoundingClientRect();
+      setIslandPosition({ left, top, width });
+    };
+    const observer = new ResizeObserver(updatePosition);
+    observer.observe(el);
+    updatePosition();
 
     const handleScroll = () => {
       const scrollTop = el.scrollTop;
@@ -65,7 +65,10 @@ export function ScrollIsland({ topics }: ScrollIslandProps) {
     el.addEventListener('scroll', handleScroll);
     handleScroll();
 
-    return () => el.removeEventListener('scroll', handleScroll);
+    return () => {
+      observer.disconnect();
+      el.removeEventListener('scroll', handleScroll);
+    };
   }, []);
 
   const handleTopicClick = (id: string) => {
@@ -84,11 +87,8 @@ export function ScrollIsland({ topics }: ScrollIslandProps) {
         }}
       >
         <div
-          className="theme-injected pointer-events-none fixed top-72 z-9999 flex justify-center pt-6 sm:top-32"
-          style={{
-            left: isMobile ? '0' : isScrollIslandPage ? '28%' : '20%',
-            width: '100%',
-          }}
+          className="theme-injected pointer-events-none fixed z-9999 flex justify-center pt-6"
+          style={islandPosition}
         >
           <motion.div
             className={cn(
@@ -152,7 +152,11 @@ export function ScrollIsland({ topics }: ScrollIslandProps) {
                     initial={{ opacity: 0 }}
                     animate={{ opacity: 1 }}
                     exit={{ opacity: 0 }}
-                    className="custom-scrollbar max-h-[60vh] w-full overflow-y-auto pt-2 pb-4"
+                    className="custom-scrollbar w-full overflow-y-auto pt-2 pb-4"
+                    style={{
+                      maxHeight:
+                        `max(0px, min(60dvh, calc(100dvh - ${islandPosition.top + 92}px)))`,
+                    }}
                   >
                     <div className="bg-border mx-2 mb-2 h-px" />
                     {topics.map((topic) => (

--- a/src/data/contents/animated-components/scroll-island/original.tsx
+++ b/src/data/contents/animated-components/scroll-island/original.tsx
@@ -32,25 +32,25 @@ export function ScrollIsland({ topics }: ScrollIslandProps) {
   const [ref, bounds] = useMeasure({ offsetSize: true });
 
   const contentRef = useRef<HTMLDivElement>(null);
-
-  const isScrollIslandPage =
-    typeof window !== 'undefined' &&
-    window.location.pathname === '/components/scroll-island';
-
-  const [isMobile, setIsMobile] = useState(false);
-
-  useEffect(() => {
-    const check = () => setIsMobile(window.innerWidth < 768);
-    check();
-    window.addEventListener('resize', check);
-    return () => window.removeEventListener('resize', check);
-  }, []);
+  const [islandPosition, setIslandPosition] = useState({
+    left: 0,
+    top: 0,
+    width: 0,
+  });
 
   useEffect(() => {
     requestAnimationFrame(() => setMounted(true));
 
     const el = contentRef.current;
     if (!el) return;
+
+    const updatePosition = () => {
+      const { left, top, width } = el.getBoundingClientRect();
+      setIslandPosition({ left, top, width });
+    };
+    const observer = new ResizeObserver(updatePosition);
+    observer.observe(el);
+    updatePosition();
 
     const handleScroll = () => {
       const scrollTop = el.scrollTop;
@@ -65,7 +65,10 @@ export function ScrollIsland({ topics }: ScrollIslandProps) {
     el.addEventListener('scroll', handleScroll);
     handleScroll();
 
-    return () => el.removeEventListener('scroll', handleScroll);
+    return () => {
+      observer.disconnect();
+      el.removeEventListener('scroll', handleScroll);
+    };
   }, []);
 
   const handleTopicClick = (id: string) => {
@@ -84,11 +87,8 @@ export function ScrollIsland({ topics }: ScrollIslandProps) {
         }}
       >
         <div
-          className="pointer-events-none fixed top-72 z-9999 flex justify-center pt-6 sm:top-32"
-          style={{
-            left: isMobile ? '0' : isScrollIslandPage ? '28%' : '20%',
-            width: '100%',
-          }}
+          className="pointer-events-none fixed z-9999 flex justify-center pt-6"
+          style={islandPosition}
         >
           <motion.div
             className={cn(
@@ -155,7 +155,11 @@ export function ScrollIsland({ topics }: ScrollIslandProps) {
                     initial={{ opacity: 0 }}
                     animate={{ opacity: 1 }}
                     exit={{ opacity: 0 }}
-                    className="custom-scrollbar max-h-[60vh] w-full overflow-y-auto pt-2 pb-4"
+                    className="custom-scrollbar w-full overflow-y-auto pt-2 pb-4"
+                    style={{
+                      maxHeight:
+                        `max(0px, min(60dvh, calc(100dvh - ${islandPosition.top + 92}px)))`,
+                    }}
                   >
                     <div className="mx-2 mb-2 h-px bg-white/5" />
                     {topics.map((topic) => (


### PR DESCRIPTION
## Description

Measure the rendered Scroll Island content area and use those bounds to position the fixed control. This replaces route-specific percentage offsets that drift when the sidebar or viewport changes.

The expanded topic list now uses the vertical space below its measured anchor and scrolls when the viewport is short. The change is applied to both the Original and Custom Theme implementations.

Fixes #192

## Before and After

### Before

The island can overlap the component description and shift away from the preview center.

![Scroll Island overlapping the component description](https://raw.githubusercontent.com/jashkarangiya/watermelon-platform/d372202282670b39eb361a49a336d907800e3089/issue-assets/scroll-island-before.png)

### After

The island stays centered within the preview and below the description.

![Scroll Island centered within the component preview](https://raw.githubusercontent.com/jashkarangiya/watermelon-platform/d372202282670b39eb361a49a336d907800e3089/issue-assets/scroll-island-after.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested both variants at widths from 320 px to 1440 px and heights from 360 px to 900 px.
- Checked the 768 px and 1024 px layout breakpoints.
- Verified the island stays centered, remains inside the viewport, and does not cover nearby text.
- Verified the constrained menu scrolls and the final topic remains selectable at 390 by 480.
- Verified live resizing, sidebar toggling, light mode, dark mode, topic selection, and backdrop closing.
- [x] Tested locally with dev server
- [x] Checked against Lint & TypeScript errors
- [x] Ran `bun run lint`
- [x] Ran `bun run build`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Documentation changes are not required
- [x] Registry changes are not required