### PR TITLE
fix: restore Voice Note send behavior

### DIFF
--- a/src/data/contents/animated-components/voice-note/base.tsx
+++ b/src/data/contents/animated-components/voice-note/base.tsx
@@ -59,12 +59,16 @@ export const VoiceNote: React.FC<VoiceNoteRecorderProps> = ({
     setState(RecorderState.REVIEWING);
   };
 
-  const cancelRecording = () => {
+  const resetRecorder = () => {
     if (timerRef.current) clearInterval(timerRef.current);
     if (playbackTimerRef.current) clearInterval(playbackTimerRef.current);
     setDuration(0);
     setPlaybackTime(0);
     setState(RecorderState.IDLE);
+  };
+
+  const cancelRecording = () => {
+    resetRecorder();
     onCancel?.();
   };
 
@@ -90,6 +94,7 @@ export const VoiceNote: React.FC<VoiceNoteRecorderProps> = ({
 
   const handleSend = () => {
     onSend?.({ duration, blob: null });
+    resetRecorder();
   };
 
   const [barHeights, setBarHeights] = useState<number[][]>([]);
@@ -266,17 +271,14 @@ export const VoiceNote: React.FC<VoiceNoteRecorderProps> = ({
                 animate={{ opacity: 1, filter: 'blur(0)', x: 0 }}
                 exit={{ opacity: 0, filter: 'blur(4px)', x: -95 }}
                 className={actionBtnClass}
+                onClick={
+                  state === RecorderState.RECORDING
+                    ? stopRecording
+                    : handleSend
+                }
               >
                 <AnimatePresence mode="popLayout">
-                  <motion.div
-                    onClick={
-                      state === RecorderState.RECORDING
-                        ? stopRecording
-                        : state === RecorderState.PLAYING
-                          ? startRecording
-                          : handleSend
-                    }
-                  >
+                  <motion.div>
                     {state === RecorderState.RECORDING && (
                       <FaCheck size={26} className="text-muted-foreground" />
                     )}

--- a/src/data/contents/animated-components/voice-note/original.tsx
+++ b/src/data/contents/animated-components/voice-note/original.tsx
@@ -52,12 +52,16 @@ export const VoiceNote: React.FC<VoiceNoteRecorderProps> = ({
     setState(RecorderState.REVIEWING);
   };
 
-  const cancelRecording = () => {
+  const resetRecorder = () => {
     if (timerRef.current) clearInterval(timerRef.current);
     if (playbackTimerRef.current) clearInterval(playbackTimerRef.current);
     setDuration(0);
     setPlaybackTime(0);
     setState(RecorderState.IDLE);
+  };
+
+  const cancelRecording = () => {
+    resetRecorder();
     onCancel?.();
   };
 
@@ -83,7 +87,7 @@ export const VoiceNote: React.FC<VoiceNoteRecorderProps> = ({
 
   const handleSend = () => {
     onSend?.({ duration, blob: null });
-
+    resetRecorder();
   };
 
   const [barHeights, setBarHeights] = useState<number[][]>([]);
@@ -272,6 +276,11 @@ export const VoiceNote: React.FC<VoiceNoteRecorderProps> = ({
                   animate={{ opacity: 1, filter: 'blur(0)', x: 0 }}
                   exit={{ opacity: 0, filter: 'blur(4px)', x: -95 }}
                   className={actionBtnClass}
+                  onClick={
+                    state === RecorderState.RECORDING
+                      ? stopRecording
+                      : handleSend
+                  }
                 >
                   <AnimatePresence mode="popLayout">
                     <motion.div
@@ -286,12 +295,6 @@ export const VoiceNote: React.FC<VoiceNoteRecorderProps> = ({
                       initial={{ opacity: 0, filter: 'blur(4px)', scale: 0.25 }}
                       animate={{ opacity: 1, filter: 'blur(0)', scale: 1 }}
                       exit={{ opacity: 0, filter: 'blur(4px)', scale: 0.25 }}
-                      onClick={
-                        state === RecorderState.RECORDING
-                          ? stopRecording
-                          : state === RecorderState.PLAYING
-                            ? startRecording : handleSend
-                      }
                     >
                       {state === RecorderState.RECORDING && (
                         <FaCheck


### PR DESCRIPTION
## Description

Fixes #198

The Voice Note send control could appear unresponsive after recording. It did not reset after sending from review, started a new recording when clicked during playback, and responded only when the icon itself was clicked.

This change:

- sends from both review and playback states
- resets timers and recorder state after the send callback without invoking `onCancel`
- moves the handler to the visible circular button so its full area is interactive
- keeps the Base and Original component variants aligned

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Tested locally with the dev server
- [x] Checked against lint and TypeScript errors
- [x] Sent from review and confirmed one callback followed by the idle microphone
- [x] Sent during playback and confirmed playback stops without restarting recording
- [x] Clicked the button padding outside the icon and confirmed it activates
- [x] Ran `bun run lint` and `bun run build`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Documentation and registry changes are not required for this bug fix

## Visual verification

### Before

After clicking Send, the recorder remains in review:

<img width="737" height="863" alt="Voice Note remains in review after Send" src="https://github.com/user-attachments/assets/6ac176c9-f754-4d56-b17f-4d319a804a98" />

### After

After sending, the recorder resets to the microphone:

<img width="737" height="863" alt="Voice Note resets after Send" src="https://github.com/user-attachments/assets/ba5a0e31-b6fd-48aa-a65f-6a7693aaae74" />